### PR TITLE
Omri/no texture io

### DIFF
--- a/open3d/geometry/Image.h
+++ b/open3d/geometry/Image.h
@@ -32,6 +32,7 @@
 #include <variant>
 #include <string>
 #include <vector>
+#include <filesystem>
 
 #include "open3d/geometry/Geometry2D.h"
 #include "open3d/utility/Console.h"
@@ -236,8 +237,7 @@ class Image : public Geometry2D {
     /// The mime type of the encoded data.
     std::string mime_type_;
   };
-  using AbsolutePath = std::string;
-  using PassThrough = std::variant<EncodedData, AbsolutePath>;
+  using PassThrough = std::variant<EncodedData, std::filesystem::path>;
   std::optional<PassThrough> pass_through_;
 };
 

--- a/open3d/geometry/Image.h
+++ b/open3d/geometry/Image.h
@@ -29,6 +29,7 @@
 #include <Eigen/Core>
 #include <memory>
 #include <optional>
+#include <variant>
 #include <string>
 #include <vector>
 
@@ -226,17 +227,18 @@ class Image : public Geometry2D {
   /// Image storage buffer.
   std::vector<uint8_t> data_;
 
-  /// Pass through data read directly from an image file without decoding the file format.
+  /// Pass through data read directly from an image file without decoding the file format. Used as an optimization
+  /// to not decode and reencode texture images on load, modify, save cycles that only modify geometry but not
+  /// textures. Also stops image quality degradation problems on each cycle with lossy image formats such as JPEG.
   struct EncodedData {
     /// The data read directly from the file without decoding the file format.
     std::vector<uint8_t> data_;
     /// The mime type of the encoded data.
     std::string mime_type_;
   };
-  /// Pass through data read directly from an image file without decoding the file format. Used as an optimization
-  /// to not decode and reencode texture images on load, modify, save cycles that only modify geometry but not
-  /// textures. Also stops image quality degradation problems on each cycle with lossy image formats such as JPEG.
-  std::optional<EncodedData> pass_through_;
+  using AbsolutePath = std::string;
+  using PassThrough = std::variant<EncodedData, AbsolutePath>;
+  std::optional<PassThrough> pass_through_;
 };
 
 }  // namespace geometry

--- a/open3d/geometry/TriangleMesh.h
+++ b/open3d/geometry/TriangleMesh.h
@@ -744,11 +744,11 @@ class TriangleMesh : public MeshBase {
       std::string alphaMode = "OPAQUE";
       double alphaCutoff = 0.5;
       std::optional<Eigen::Vector3d> emissiveFactor;
-      double texture_idx = -1; // If this material should point to a texture, provide the idx
+      std::optional<unsigned int> texture_idx; // If this material should point to a texture, provide the idx
 
       bool operator==(const GltfExtras &other) const {
         return (doubleSided == other.doubleSided && alphaMode == other.alphaMode && alphaCutoff == other.alphaCutoff &&
-                emissiveFactor == other.emissiveFactor);
+                emissiveFactor == other.emissiveFactor && texture_idx == other.texture_idx);
       }
 
       bool operator!=(const GltfExtras &other) const { return (!(*this == other)); }

--- a/open3d/io/ImageIO.cpp
+++ b/open3d/io/ImageIO.cpp
@@ -75,18 +75,8 @@ bool ReadImage(const std::string &filename, geometry::Image &image) {
 }
 
 bool WriteImage(const std::string &filename, const geometry::Image &image, int quality /* = 90*/) {
-  std::string filename_ext = utility::filesystem::GetFileExtensionInLowerCase(filename);
-  if (filename_ext.empty()) {
-    utility::LogWarning("Write geometry::Image failed: unknown file extension.");
-    return false;
-  }
-  auto map_itr = file_extension_to_image_write_function.find(filename_ext);
-  if (map_itr == file_extension_to_image_write_function.end()) {
-    utility::LogWarning("Write geometry::Image failed: unknown file extension.");
-    return false;
-  }
   if (image.pass_through_.has_value()) {
-    std::visit(
+    return(std::visit(
         [&](const auto &pass_through) {
           using PassThroughType = typename std::decay<decltype(pass_through)>::type;
           if constexpr (std::is_same<PassThroughType, geometry::Image::EncodedData>::value) {
@@ -94,7 +84,7 @@ bool WriteImage(const std::string &filename, const geometry::Image &image, int q
             if (!file_out.is_open()) {
               return false;
             }
-            file_out.write(reinterpret_cast<const char *>(pass_through.data()), pass_through.size());
+            file_out.write(reinterpret_cast<const char *>(pass_through.data_.data()), pass_through.data_.size());
             file_out.close();
             return true;
           } else if constexpr (std::is_same<PassThroughType, geometry::Image::AbsolutePath>::value) {
@@ -114,8 +104,18 @@ bool WriteImage(const std::string &filename, const geometry::Image &image, int q
             return true;
           }
         },
-        *image.pass_through_)
+        *image.pass_through_));
   } else {
+    std::string filename_ext = utility::filesystem::GetFileExtensionInLowerCase(filename);
+    if (filename_ext.empty()) {
+      utility::LogWarning("Write geometry::Image failed: unknown file extension.");
+      return false;
+    }
+    auto map_itr = file_extension_to_image_write_function.find(filename_ext);
+    if (map_itr == file_extension_to_image_write_function.end()) {
+      utility::LogWarning("Write geometry::Image failed: unknown file extension.");
+      return false;
+    }
     return map_itr->second(filename, image, quality);
   }
 }

--- a/open3d/io/ImageIO.cpp
+++ b/open3d/io/ImageIO.cpp
@@ -88,9 +88,12 @@ bool WriteImage(const std::string &filename, const geometry::Image &image, int q
   if (image.pass_through_.has_value()) {
     std::visit(
         [&](const auto &pass_through) {
-          using PassThroughType = std::decay<decltype(pass_through)>::type;
+          using PassThroughType = typename std::decay<decltype(pass_through)>::type;
           if constexpr (std::is_same<PassThroughType, geometry::Image::EncodedData>::value) {
             std::ofstream file_out(filename, std::ios::out | std::ios::binary);
+            if (!file_out.is_open()) {
+              return false;
+            }
             file_out.write(reinterpret_cast<const char *>(pass_through.data()), pass_through.size());
             file_out.close();
             return true;
@@ -103,6 +106,9 @@ bool WriteImage(const std::string &filename, const geometry::Image &image, int q
               return false;
             }
             std::ofstream file_out(filename, std::ios::out | std::ios::binary);
+            if (!file_out.is_open()) {
+              return false;
+            }
             file_out.write(buffer.data(), pass_through.size());
             file_out.close();
             return true;

--- a/open3d/io/ImageIO.cpp
+++ b/open3d/io/ImageIO.cpp
@@ -88,8 +88,8 @@ bool WriteImage(const std::string &filename, const geometry::Image &image, int q
             file_out.write(reinterpret_cast<const char *>(pass_through.data_.data()), pass_through.data_.size());
             file_out.close();
             return true;
-          } else if constexpr (std::is_same<PassThroughType, geometry::Image::AbsolutePath>::value) {
-            if(std::filesystem::path(pass_through) == std::filesystem::path(filename)) {
+          } else if constexpr (std::is_same<PassThroughType, std::filesystem::path>::value) {
+            if(pass_through == std::filesystem::path(filename)) {
               return true;
             }
             return std::filesystem::copy_file(pass_through, filename);

--- a/open3d/io/ImageIO.cpp
+++ b/open3d/io/ImageIO.cpp
@@ -28,6 +28,7 @@
 
 #include <fstream>
 #include <unordered_map>
+#include <filesystem>
 
 #include "open3d/utility/Console.h"
 #include "open3d/utility/FileSystem.h"
@@ -88,20 +89,10 @@ bool WriteImage(const std::string &filename, const geometry::Image &image, int q
             file_out.close();
             return true;
           } else if constexpr (std::is_same<PassThroughType, geometry::Image::AbsolutePath>::value) {
-            if(utility::filesystem::AreEqual(pass_through, filename)) {
+            if(std::filesystem::path(pass_through) == std::filesystem::path(filename)) {
               return true;
             }
-            std::vector<char> buffer;
-            if(!utility::filesystem::FReadToBuffer(filename, buffer, nullptr)) {
-              return false;
-            }
-            std::ofstream file_out(filename, std::ios::out | std::ios::binary);
-            if (!file_out.is_open()) {
-              return false;
-            }
-            file_out.write(buffer.data(), pass_through.size());
-            file_out.close();
-            return true;
+            return std::filesystem::copy_file(pass_through, filename);
           }
         },
         *image.pass_through_));

--- a/open3d/io/ImageIO.cpp
+++ b/open3d/io/ImageIO.cpp
@@ -88,7 +88,7 @@ bool WriteImage(const std::string &filename, const geometry::Image &image, int q
             file_out.close();
             return true;
           } else if constexpr (std::is_same<PassThroughType, geometry::Image::AbsolutePath>::value) {
-            if(pass_through == filename) {
+            if(utility::filesystem::AreEqual(pass_through, filename)) {
               return true;
             }
             std::vector<char> buffer;

--- a/open3d/io/TriangleMeshIO.cpp
+++ b/open3d/io/TriangleMeshIO.cpp
@@ -38,10 +38,16 @@ namespace {
 using namespace io;
 
 static const std::function<bool(const std::string &, geometry::TriangleMesh &, bool)> GetReadMeshFunction(const std::string ext,
-                                                                                                          bool tex_pass_through) {
+                                                                                                          TextureLoadMode texture_load_mode) {
   if (ext == "gltf" || ext == "glb") {
-    // Note CH: Texture pass through is only implemented for reading GLTF meshes
-    return tex_pass_through ? ReadTriangleMeshFromGLTFWithTexturePassThrough : ReadTriangleMeshFromGLTF;
+    switch(texture_load_mode) {
+      case TextureLoadMode::normal: {
+        return(ReadTriangleMeshFromGLTF);
+      }
+      case TextureLoadMode::pass_through: {
+        return(ReadTriangleMeshFromGLTFWithTexturePassThrough);
+      }
+    }
   } else if (ext == "obj") {
     return ReadTriangleMeshFromOBJ;
   } else if (ext == "ply") {
@@ -73,7 +79,7 @@ std::shared_ptr<geometry::TriangleMesh> CreateMeshFromFile(const std::string &fi
 }
 
 bool ReadTriangleMesh(const std::string &filename, geometry::TriangleMesh &mesh, bool print_progress /* = false */,
-                      bool texture_pass_through_if_available /* = false */) {
+                      TextureLoadMode texture_load_mode) {
   std::string filename_ext = utility::filesystem::GetFileExtensionInLowerCase(filename);
   if (filename_ext.empty()) {
     utility::LogWarning(
@@ -81,7 +87,7 @@ bool ReadTriangleMesh(const std::string &filename, geometry::TriangleMesh &mesh,
         "extension.");
     return false;
   }
-  bool success = GetReadMeshFunction(filename_ext, texture_pass_through_if_available)(filename, mesh, print_progress);
+  bool success = GetReadMeshFunction(filename_ext, texture_load_mode)(filename, mesh, print_progress);
   utility::LogDebug("Read geometry::TriangleMesh: {:d} triangles and {:d} vertices.", (int)mesh.triangles_.size(), (int)mesh.vertices_.size());
   if (mesh.HasVertices() && !mesh.HasTriangles()) {
     utility::LogWarning(

--- a/open3d/io/TriangleMeshIO.cpp
+++ b/open3d/io/TriangleMeshIO.cpp
@@ -47,6 +47,9 @@ static const std::function<bool(const std::string &, geometry::TriangleMesh &, b
       case TextureLoadMode::pass_through: {
         return(ReadTriangleMeshFromGLTFWithTexturePassThrough);
       }
+      case TextureLoadMode::ignore_external_files: {
+        return(ReadTriangleMeshFromGLTFWithIgnoringExternalTextures);
+      }
     }
   } else if (ext == "obj") {
     return ReadTriangleMeshFromOBJ;

--- a/open3d/io/TriangleMeshIO.h
+++ b/open3d/io/TriangleMeshIO.h
@@ -37,12 +37,17 @@ namespace io {
 /// Return an empty mesh if fail to read the file.
 std::shared_ptr<geometry::TriangleMesh> CreateMeshFromFile(const std::string &filename, bool print_progress = false);
 
+enum class TextureLoadMode {
+  normal,
+  pass_through // Textures are not decoded on loading, nor encoded on writing. Only available with GLB and GLTF files.
+};
+
 /// The general entrance for reading a TriangleMesh from a file
 /// The function calls read functions based on the extension name of filename.
 /// \return return true if the read function is successful, false otherwise.
 /// @note texture pass through will be skipped on mesh formats that do not support it
 bool ReadTriangleMesh(const std::string &filename, geometry::TriangleMesh &mesh, bool print_progress = false,
-                      bool texture_pass_through_if_available = false);
+                      TextureLoadMode texture_load_mode = TextureLoadMode::normal);
 
 /// The general entrance for writing a TriangleMesh to a file
 /// The function calls write functions based on the extension name of filename.

--- a/open3d/io/TriangleMeshIO.h
+++ b/open3d/io/TriangleMeshIO.h
@@ -39,7 +39,9 @@ std::shared_ptr<geometry::TriangleMesh> CreateMeshFromFile(const std::string &fi
 
 enum class TextureLoadMode {
   normal,
-  pass_through // Textures are not decoded on loading, nor encoded on writing. Only available with GLB and GLTF files.
+  pass_through, // Textures are not decoded on loading, nor encoded on writing. Only available with GLB and GLTF files.
+  ignore_external_files // External texture files are neither read or written on writing. Only available with GLTF files. Resorts to
+      // pass through on GLB files, embedded textures on GLTF files and is ignored on other formats.
 };
 
 /// The general entrance for reading a TriangleMesh from a file
@@ -82,6 +84,7 @@ bool WriteTriangleMeshToOFF(const std::string &filename, const geometry::Triangl
 
 bool ReadTriangleMeshFromGLTF(const std::string &filename, geometry::TriangleMesh &mesh, bool print_progress);
 bool ReadTriangleMeshFromGLTFWithTexturePassThrough(const std::string &filename, geometry::TriangleMesh &mesh, bool print_progress);
+bool ReadTriangleMeshFromGLTFWithIgnoringExternalTextures(const std::string &filename, geometry::TriangleMesh &mesh, bool print_progress);
 
 bool WriteTriangleMeshToGLTF(const std::string &filename, const geometry::TriangleMesh &mesh, bool write_ascii, bool compressed,
                              bool write_vertex_normals, bool write_vertex_colors, bool write_triangle_uvs, bool print_progress);

--- a/open3d/io/file_format/FileGLTF.cpp
+++ b/open3d/io/file_format/FileGLTF.cpp
@@ -1000,7 +1000,7 @@ bool SaveMeshGLTF(const std::string &fileName, const geometry::TriangleMesh &_me
 
   // setup GLTF
   tinygltf::TinyGLTF gltf;
-  const bool bEmbedImages(true), bEmbedBuffers(true), bPrettyPrint(false);
+  const bool bEmbedImages(bBinary), bEmbedBuffers(bBinary), bPrettyPrint(false);
   return gltf.WriteGltfSceneToFile(&gltfModel, fileName, bEmbedImages, bEmbedBuffers, bPrettyPrint, bBinary);
 }
 

--- a/open3d/io/file_format/FileGLTF.cpp
+++ b/open3d/io/file_format/FileGLTF.cpp
@@ -1000,7 +1000,7 @@ bool SaveMeshGLTF(const std::string &fileName, const geometry::TriangleMesh &_me
 
   // setup GLTF
   tinygltf::TinyGLTF gltf;
-  const bool bEmbedImages(bBinary), bEmbedBuffers(bBinary), bPrettyPrint(false);
+  const bool bEmbedImages(bBinary), bEmbedBuffers(bBinary), bPrettyPrint(!bBinary);
   return gltf.WriteGltfSceneToFile(&gltfModel, fileName, bEmbedImages, bEmbedBuffers, bPrettyPrint, bBinary);
 }
 

--- a/open3d/io/file_format/FileGLTF.cpp
+++ b/open3d/io/file_format/FileGLTF.cpp
@@ -83,7 +83,7 @@ static geometry::Image::EncodedData EncodeImage(const geometry::Image &image, co
         [&](const auto &pass_through) {
           using PassThroughType = typename std::decay<decltype(pass_through)>::type;
           if constexpr (std::is_same<PassThroughType, geometry::Image::EncodedData>::value) {
-            return (geometry::Image::EncodedData{image.pass_through_->data_, image.pass_through_->mime_type_});
+            return (geometry::Image::EncodedData{pass_through->data_, pass_through->mime_type_});
           } else if constexpr (std::is_same<PassThroughType, geometry::Image::AbsolutePath>::value) {
             return (geometry::Image::EncodedData{ReadFileIntoBuffer(pass_through), GetMimeType(pass_through)});
           }
@@ -101,7 +101,7 @@ static geometry::Image ToOpen3d(const tinygltf::Image &tinygltf_image, TextureLo
   geometry::Image open3d_image;
   if (texture_load_mode == TextureLoadMode::ignore_external_files && !tinygltf_image.uri.empty() && tinygltf_image.image.empty()) {
     //! @todo Make path absolute
-    open3d_image.pass_through_ = geometry::Image::AbsolutePath(inygltf_image.uri);
+    open3d_image.pass_through_ = geometry::Image::AbsolutePath(tinygltf_image.uri);
   } else if (tinygltf_image.as_is) {
     open3d_image.pass_through_ = geometry::Image::EncodedData{tinygltf_image.image, GetMimeType(tinygltf_image)};
     // Make a fake 1x1 RGB image just in case somewhere else in Open3D the image integrity is verified.

--- a/open3d/io/file_format/FileGLTF.cpp
+++ b/open3d/io/file_format/FileGLTF.cpp
@@ -83,7 +83,7 @@ static geometry::Image::EncodedData EncodeImage(const geometry::Image &image, co
         [&](const auto &pass_through) {
           using PassThroughType = typename std::decay<decltype(pass_through)>::type;
           if constexpr (std::is_same<PassThroughType, geometry::Image::EncodedData>::value) {
-            return (geometry::Image::EncodedData{pass_through->data_, pass_through->mime_type_});
+            return (geometry::Image::EncodedData{pass_through.data_, pass_through.mime_type_});
           } else if constexpr (std::is_same<PassThroughType, geometry::Image::AbsolutePath>::value) {
             return (geometry::Image::EncodedData{ReadFileIntoBuffer(pass_through), GetMimeType(pass_through)});
           }

--- a/open3d/io/file_format/FileGLTF.cpp
+++ b/open3d/io/file_format/FileGLTF.cpp
@@ -50,21 +50,9 @@ static std::string GetMimeType(const tinygltf::Image &image) {
   if (!image.mimeType.empty()) {
     return (image.mimeType);
   }
-  const auto extension_period_position = image.uri.rfind('.');
-  if (extension_period_position == std::string::npos) {
-    return ("");
-  }
-  const auto extension = image.uri.substr(extension_period_position + 1u);
-  if (extension == "jpg" || extension == "jpeg") {
-    return ("image/jpeg");
-  } else if (extension == "png") {
-    return ("image/png");
-  } else if (extension == "basis") {
-    return ("image/basis");
-  } else {
-    return ("");
-  }
+  return(utility::filesystem::GetMimeType(image.uri));
 }
+
 static std::vector<uint8_t> ReadFileIntoBuffer(const std::string &path) {
   auto stream = std::ifstream(path, std::ios::in | std::ios::binary);
   stream.seekg(0, std::ios::end);
@@ -85,7 +73,7 @@ static geometry::Image::EncodedData EncodeImage(const geometry::Image &image, co
           if constexpr (std::is_same<PassThroughType, geometry::Image::EncodedData>::value) {
             return (geometry::Image::EncodedData{pass_through.data_, pass_through.mime_type_});
           } else if constexpr (std::is_same<PassThroughType, geometry::Image::AbsolutePath>::value) {
-            return (geometry::Image::EncodedData{ReadFileIntoBuffer(pass_through), GetMimeType(pass_through)});
+            return (geometry::Image::EncodedData{ReadFileIntoBuffer(pass_through), utility::filesystem::GetMimeType(pass_through)});
           }
         },
         *image.pass_through_));

--- a/open3d/io/file_format/FileGLTF.cpp
+++ b/open3d/io/file_format/FileGLTF.cpp
@@ -30,6 +30,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <filesystem>
 #include <numeric>
 #include <vector>
 
@@ -50,7 +51,7 @@ static std::string GetMimeType(const tinygltf::Image &image) {
   if (!image.mimeType.empty()) {
     return (image.mimeType);
   }
-  return(utility::filesystem::GetMimeType(image.uri));
+  return (utility::filesystem::GetMimeType(image.uri));
 }
 
 static std::vector<uint8_t> ReadFileIntoBuffer(const std::string &path) {
@@ -85,11 +86,13 @@ static geometry::Image::EncodedData EncodeImage(const geometry::Image &image, co
   }
 }
 
-static geometry::Image ToOpen3d(const tinygltf::Image &tinygltf_image, TextureLoadMode texture_load_mode) {
+static geometry::Image ToOpen3d(const tinygltf::Image &tinygltf_image, TextureLoadMode texture_load_mode,
+                                const std::filesystem::path &parent_directory) {
   geometry::Image open3d_image;
-  if (texture_load_mode == TextureLoadMode::ignore_external_files && !tinygltf_image.uri.empty() && tinygltf_image.image.empty()) {
-    //! @todo Make path absolute
-    open3d_image.pass_through_ = geometry::Image::AbsolutePath(tinygltf_image.uri);
+  if (texture_load_mode == TextureLoadMode::ignore_external_files && !tinygltf_image.uri.empty() && !tinygltf::IsDataURI(tinygltf_image.uri) &&
+      tinygltf_image.image.empty()) {
+    const auto absolute_path = std::filesystem::canonical(parent_directory / std::filesystem::path(tinygltf_image.uri));
+    open3d_image.pass_through_ = geometry::Image::AbsolutePath(absolute_path.string());
   } else if (tinygltf_image.as_is) {
     open3d_image.pass_through_ = geometry::Image::EncodedData{tinygltf_image.image, GetMimeType(tinygltf_image)};
     // Make a fake 1x1 RGB image just in case somewhere else in Open3D the image integrity is verified.
@@ -179,6 +182,7 @@ bool ReadTriangleMeshFromGLTFWithOptions(const std::string &filename, geometry::
                                          TextureLoadMode texture_load_mode) {
   std::string filename_ext = utility::filesystem::GetFileExtensionInLowerCase(filename);
   const bool bBinary(filename_ext == "glb");
+  const auto parent_directory = std::filesystem::path(filename).parent_path();
 
   tinygltf::Model model;
   tinygltf::TinyGLTF loader;
@@ -391,7 +395,7 @@ bool ReadTriangleMeshFromGLTFWithOptions(const std::string &filename, geometry::
             const tinygltf::Texture &gltf_texture = model.textures[gltf_material.pbrMetallicRoughness.baseColorTexture.index];
             if (gltf_texture.source >= 0) {
               const tinygltf::Image &gltf_image = model.images[gltf_texture.source];
-              mesh_temp.textures_.emplace_back(ToOpen3d(gltf_image, texture_load_mode));
+              mesh_temp.textures_.emplace_back(ToOpen3d(gltf_image, texture_load_mode, parent_directory));
               material.gltfExtras.texture_idx = mesh.textures_.size();
               std::vector<Eigen::Vector2d> triangle_uvs_;
               FOREACH(i, mesh_temp.triangles_) {
@@ -409,7 +413,7 @@ bool ReadTriangleMeshFromGLTFWithOptions(const std::string &filename, geometry::
             if (gltf_texture.source >= 0) {
               const tinygltf::Image &gltf_image = model.images[gltf_texture.source];
               assert(!mesh_temp.triangles_.empty() && !mesh_temp.triangle_uvs_.empty());
-              material.normalMap = std::make_shared<geometry::Image>(ToOpen3d(gltf_image, texture_load_mode));
+              material.normalMap = std::make_shared<geometry::Image>(ToOpen3d(gltf_image, texture_load_mode, parent_directory));
             }
           }
           if (gltf_material.occlusionTexture.index >= 0) {
@@ -417,7 +421,7 @@ bool ReadTriangleMeshFromGLTFWithOptions(const std::string &filename, geometry::
             if (gltf_texture.source >= 0) {
               const tinygltf::Image &gltf_image = model.images[gltf_texture.source];
               assert(!mesh_temp.triangles_.empty() && !mesh_temp.triangle_uvs_.empty());
-              material.ambientOcclusion = std::make_shared<geometry::Image>(std::move(ToOpen3d(gltf_image, texture_load_mode)));
+              material.ambientOcclusion = std::make_shared<geometry::Image>(std::move(ToOpen3d(gltf_image, texture_load_mode, parent_directory)));
             }
           }
 
@@ -426,7 +430,7 @@ bool ReadTriangleMeshFromGLTFWithOptions(const std::string &filename, geometry::
             if (gltf_texture.source >= 0) {
               const tinygltf::Image &gltf_image = model.images[gltf_texture.source];
               assert(!mesh_temp.triangles_.empty() && !mesh_temp.triangle_uvs_.empty());
-              material.roughness = std::make_shared<geometry::Image>(std::move(ToOpen3d(gltf_image, texture_load_mode)));
+              material.roughness = std::make_shared<geometry::Image>(std::move(ToOpen3d(gltf_image, texture_load_mode, parent_directory)));
             }
           }
         }
@@ -798,6 +802,20 @@ static void InitializeGltfMaterial(tinygltf::Material &material, const geometry:
   }
 }
 
+static std::optional<tinygltf::Image> TrySkippedExternalTexture(const geometry::Image &image, const std::filesystem::path &parent_directory) {
+  if (image.pass_through_.has_value()) {
+    const auto *absolute_path = std::get_if<geometry::Image::AbsolutePath>(&*image.pass_through_);
+    if (absolute_path != nullptr) {
+      const auto relative_path = std::filesystem::relative(*absolute_path, parent_directory);
+      tinygltf::Image gltf_image;
+      gltf_image.uri = relative_path.string();
+      gltf_image.mimeType = utility::filesystem::GetMimeType(*absolute_path);
+      return (gltf_image);
+    }
+  }
+  return (std::optional<tinygltf::Image>());
+}
+
 // export the mesh as a GLTF file
 bool SaveMeshGLTF(const std::string &fileName, const geometry::TriangleMesh &_mesh) {
   const std::string path = utility::filesystem::GetFileParentDirectory(fileName);
@@ -805,15 +823,6 @@ bool SaveMeshGLTF(const std::string &fileName, const geometry::TriangleMesh &_me
     utility::filesystem::MakeDirectoryHierarchy(path);
   std::string filename_ext = utility::filesystem::GetFileExtensionInLowerCase(fileName);
   const bool bBinary(filename_ext == "glb");
-  auto has_ignored_external_textures = false;
-  for (const auto &texture : _mesh.textures_) {
-    if (texture.pass_through_.has_value()) {
-      if (std::get_if<geometry::Image::AbsolutePath>(&*texture.pass_through_) != nullptr) {
-        has_ignored_external_textures = true;
-        break;
-      }
-    }
-  }
 
   // split mesh such that the texture coordinates are per vertex instead of per
   // face
@@ -829,24 +838,23 @@ bool SaveMeshGLTF(const std::string &fileName, const geometry::TriangleMesh &_me
   tinygltf::Mesh gltfMesh;
   tinygltf::Buffer gltfBuffer;
 
+  const auto parent_directory = std::filesystem::path(fileName).parent_path();
   auto add_image = [&](const geometry::Image &image, const std::string &temporary_file_name) {
-    if (has_ignored_external_textures && image.pass_through_.has_value()) {
-      const auto *absolute_path = std::get_if<geometry::Image::AbsolutePath>(&*image.pass_through_);
-      if (absolute_path != nullptr) {
-        //! @todo
-        return;
-      }
+    auto skipped_external_texture = TrySkippedExternalTexture(image, parent_directory);
+    if (skipped_external_texture.has_value()) {
+      gltfModel.images.push_back(std::move(*skipped_external_texture));
+    } else {
+      const auto encoded_data = EncodeImage(image, path + temporary_file_name);
+      tinygltf::Image gltf_image;
+      gltf_image.mimeType = encoded_data.mime_type_;
+      gltf_image.bufferView = gltfModel.bufferViews.size();
+      gltf_image.as_is = true;
+      tinygltf::BufferView imageBufferView;
+      imageBufferView.buffer = gltfModel.buffers.size();
+      extendBuffer(encoded_data.data_, gltfBuffer, imageBufferView.byteOffset, imageBufferView.byteLength);
+      gltfModel.bufferViews.emplace_back(std::move(imageBufferView));
+      gltfModel.images.emplace_back(std::move(gltf_image));
     }
-    const auto encoded_data = EncodeImage(image, path + temporary_file_name);
-    tinygltf::Image gltf_image;
-    gltf_image.mimeType = encoded_data.mime_type_;
-    gltf_image.bufferView = gltfModel.bufferViews.size();
-    gltf_image.as_is = true;
-    tinygltf::BufferView imageBufferView;
-    imageBufferView.buffer = gltfModel.buffers.size();
-    extendBuffer(encoded_data.data_, gltfBuffer, imageBufferView.byteOffset, imageBufferView.byteLength);
-    gltfModel.bufferViews.emplace_back(std::move(imageBufferView));
-    gltfModel.images.emplace_back(std::move(gltf_image));
   };
 
   for (const geometry::TriangleMesh &mesh : meshes) {
@@ -1149,18 +1157,22 @@ inline tinygltf::Model WriteTexturedTriangleMeshToGLTFModel(const std::string &f
       gltf_primitive.attributes.insert(std::make_pair("TEXCOORD_0", static_cast<int>(model.accessors.size()) - 1));
       gltf_primitive.material = tex_idx;
 
-      auto encoded_image = EncodeImage(mesh.textures_[tex_idx], parent_dir + "texture" + std::to_string(tex_idx) + ".jpg");
       tinygltf::Image image;
-
-      // Save the bytes to the GLTF directly.
-      image.mimeType = encoded_image.mime_type_;
-      tinygltf::BufferView image_buffer_view;
-      image_buffer_view.name = "buffer-" + std::to_string(tex_idx) + "-bufferview-image-0";
-      image_buffer_view.buffer = model.buffers.size();
-      extendBuffer(encoded_image.data_, buffer, image_buffer_view.byteOffset, image_buffer_view.byteLength);
-      model.bufferViews.push_back(image_buffer_view);
-      image.bufferView = model.bufferViews.size() - 1;
-      image.as_is = true;
+      auto skipped_external_texture = TrySkippedExternalTexture(mesh.textures_[tex_idx], std::filesystem::path(parent_dir));
+      if (skipped_external_texture.has_value()) {
+        image = std::move(*skipped_external_texture);
+      } else {
+        // Save the bytes to the GLTF directly.
+        auto encoded_image = EncodeImage(mesh.textures_[tex_idx], parent_dir + "texture" + std::to_string(tex_idx) + ".jpg");
+        image.mimeType = encoded_image.mime_type_;
+        tinygltf::BufferView image_buffer_view;
+        image_buffer_view.name = "buffer-" + std::to_string(tex_idx) + "-bufferview-image-0";
+        image_buffer_view.buffer = model.buffers.size();
+        extendBuffer(encoded_image.data_, buffer, image_buffer_view.byteOffset, image_buffer_view.byteLength);
+        model.bufferViews.push_back(image_buffer_view);
+        image.bufferView = model.bufferViews.size() - 1;
+        image.as_is = true;
+      }
 
       tinygltf::Material gltf_mat;
       gltf_mat.pbrMetallicRoughness.metallicFactor = 0.0;
@@ -1386,7 +1398,7 @@ inline tinygltf::Model WriteTriangleMeshToGLTFModel(const std::string &filename,
   model.bufferViews[1].byteOffset = index_buffer.size();
 
   tinygltf::Buffer buffer;
-  buffer.uri = filename.substr(0, filename.find_last_of(".")) + ".bin";
+  buffer.uri = "geometry.bin";
   buffer.data.resize(index_buffer.size() + mesh_attribute_buffer.size());
   memcpy(buffer.data.data(), index_buffer.data(), index_buffer.size());
   memcpy(buffer.data.data() + index_buffer.size(), mesh_attribute_buffer.data(), mesh_attribute_buffer.size());

--- a/open3d/io/file_format/FileGLTF.cpp
+++ b/open3d/io/file_format/FileGLTF.cpp
@@ -81,7 +81,7 @@ static geometry::Image::EncodedData EncodeImage(const geometry::Image &image, co
   if (image.pass_through_.has_value()) {
     return (std::visit(
         [&](const auto &pass_through) {
-          using PassThroughType = std::decay<decltype(pass_through)>::type;
+          using PassThroughType = typename std::decay<decltype(pass_through)>::type;
           if constexpr (std::is_same<PassThroughType, geometry::Image::EncodedData>::value) {
             return (geometry::Image::EncodedData{image.pass_through_->data_, image.pass_through_->mime_type_});
           } else if constexpr (std::is_same<PassThroughType, geometry::Image::AbsolutePath>::value) {

--- a/open3d/io/file_format/FileGLTF.cpp
+++ b/open3d/io/file_format/FileGLTF.cpp
@@ -814,6 +814,7 @@ static std::optional<tinygltf::Image> TrySkippedExternalTexture(const geometry::
       tinygltf::Image gltf_image;
       gltf_image.uri = relative_path.string();
       gltf_image.mimeType = utility::filesystem::GetMimeType(*absolute_path);
+      gltf_image.name = absolute_path->stem().string();
       return (gltf_image);
     }
   }

--- a/open3d/io/file_format/FileOBJ.cpp
+++ b/open3d/io/file_format/FileOBJ.cpp
@@ -364,10 +364,10 @@ bool WriteTriangleMeshToOBJ(const std::string &filename, const geometry::Triangl
     mtl_file << "# object name: " << object_name << "\n";
     for (auto it : mesh.materials_) {
       const geometry::TriangleMesh::Material &material = it.second;
-      int texture_idx = material.gltfExtras.texture_idx;
+      std::optional<unsigned int> texture_idx = material.gltfExtras.texture_idx;
       std::string mtl_name = object_name + "_" + it.first;
-      std::string tex_name = object_name + "_" + std::to_string(texture_idx);
-      if (texture_idx < 0) { // Solid color - not a texture
+      std::string tex_name = object_name + "_" + (texture_idx.has_value() ? std::to_string(*texture_idx) : (std::string)"-1");
+      if (!texture_idx.has_value()) { // Solid color - not a texture
         const auto &spectral = material.gltfExtras.emissiveFactor;
         mtl_file << "newmtl " << mtl_name << "\n";
         mtl_file << "Ka 0.000 0.000 0.000\n";

--- a/open3d/utility/FileSystem.cpp
+++ b/open3d/utility/FileSystem.cpp
@@ -75,11 +75,6 @@ std::string GetMimeType(const std::string &filename) {
   }
 }
 
-bool AreEqual(const std::string &filename1, const std::string &filename2) {
-  return(std::equal(filename1.begin(), filename1.end(), filename2.begin(), filename2.end(),
-    [](char character1, char character2) { return(::tolower(character1) == ::tolower(character2)); }));
-}
-
 std::string GetFileExtensionInLowerCase(const std::string &filename) {
   size_t dot_pos = filename.find_last_of(".");
   if (dot_pos >= filename.length())

--- a/open3d/utility/FileSystem.cpp
+++ b/open3d/utility/FileSystem.cpp
@@ -58,6 +58,28 @@ namespace open3d {
 namespace utility {
 namespace filesystem {
 
+std::string GetMimeType(const std::string &filename) {
+  const auto extension = GetFileExtensionInLowerCase(filename);
+  if (extension == "jpg" || extension == "jpeg") {
+    return ("image/jpeg");
+  } else if (extension == "png") {
+    return ("image/png");
+  } else if (extension == "basis") {
+    return ("image/basis");
+  } else if (extension == "gltf") {
+    return ("model/gltf+json");
+  } else if (extension == "glb") {
+    return ("model/gltf-binary");
+  } else {
+    return ("");
+  }
+}
+
+bool AreEqual(const std::string &filename1, const std::string &filename2) {
+  return(std::equal(filename1.begin(), filename1.end(), filename2.begin(), filename2.end(),
+    [](char character1, char character2) { return(::tolower(character1) == ::tolower(character2)); }));
+}
+
 std::string GetFileExtensionInLowerCase(const std::string &filename) {
   size_t dot_pos = filename.find_last_of(".");
   if (dot_pos >= filename.length())

--- a/open3d/utility/FileSystem.h
+++ b/open3d/utility/FileSystem.h
@@ -33,6 +33,10 @@ namespace open3d {
 namespace utility {
 namespace filesystem {
 
+std::string GetMimeType(const std::string &filename);
+
+bool AreEqual(const std::string &filename1, const std::string &filename2);
+
 std::string GetFileExtensionInLowerCase(const std::string &filename);
 
 std::string GetFileNameWithoutExtension(const std::string &filename);

--- a/open3d/utility/FileSystem.h
+++ b/open3d/utility/FileSystem.h
@@ -35,8 +35,6 @@ namespace filesystem {
 
 std::string GetMimeType(const std::string &filename);
 
-bool AreEqual(const std::string &filename1, const std::string &filename2);
-
 std::string GetFileExtensionInLowerCase(const std::string &filename);
 
 std::string GetFileNameWithoutExtension(const std::string &filename);


### PR DESCRIPTION
Infrastructure for supporting updating geometry without reading or writing external texture files for JSON based GLTF files. Adds `io::TextureLoadMode` to load texture normally (decoded into buffers), pass through (encoded into buffers, what was already in place) and ignore external files (neither read or write external texture files, just leave an absolute path placeholder. Also saves texture externally in the `assets` directory for JSON based GLTF files instead of embedding them in the the binary buffer file.