### PR TITLE
Omri/fix external image extension

### DIFF
--- a/open3d/io/file_format/FileGLTF.cpp
+++ b/open3d/io/file_format/FileGLTF.cpp
@@ -884,7 +884,7 @@ bool SaveMeshGLTF(const std::string &fileName, const geometry::TriangleMesh &_me
         gltf_image.name = texture_name;
         const auto relative_texture_file =
             assets_relative_directory /
-            std::filesystem::path(texture_name + '.' + GetExtension(encoded_data.mime_type_));
+            std::filesystem::path(texture_name + '.' + utility::filesystem::GetExtension(encoded_data.mime_type_));
         const auto texture_file = parent_directory / relative_texture_file;
         gltf_image.uri = relative_texture_file.string();
         if (!created_assets_directory) {

--- a/open3d/io/file_format/FileGLTF.cpp
+++ b/open3d/io/file_format/FileGLTF.cpp
@@ -884,7 +884,7 @@ bool SaveMeshGLTF(const std::string &fileName, const geometry::TriangleMesh &_me
         gltf_image.name = texture_name;
         const auto relative_texture_file =
             assets_relative_directory /
-            std::filesystem::path(texture_name + '.' + utility::filesystem::GetFileExtensionInLowerCase(temporary_file_name));
+            std::filesystem::path(texture_name + '.' + GetExtension(encoded_data.mime_type_));
         const auto texture_file = parent_directory / relative_texture_file;
         gltf_image.uri = relative_texture_file.string();
         if (!created_assets_directory) {

--- a/open3d/utility/FileSystem.cpp
+++ b/open3d/utility/FileSystem.cpp
@@ -75,6 +75,22 @@ std::string GetMimeType(const std::string &filename) {
   }
 }
 
+std::string GetExtension(const std::string &mime_type) {
+  if (mime_type == "image/jpeg") {
+    return ("jpg");
+  } else if (mime_type == "image/png") {
+    return ("png");
+  } else if (mime_type == "image/basis") {
+    return ("basis");
+  } else if (mime_type == "model/gltf+json") {
+    return ("gltf");
+  } else if (mime_type == "model/gltf-binary") {
+    return ("glb");
+  } else {
+    return ("");
+  }
+}
+
 std::string GetFileExtensionInLowerCase(const std::string &filename) {
   size_t dot_pos = filename.find_last_of(".");
   if (dot_pos >= filename.length())

--- a/open3d/utility/FileSystem.h
+++ b/open3d/utility/FileSystem.h
@@ -35,6 +35,8 @@ namespace filesystem {
 
 std::string GetMimeType(const std::string &filename);
 
+std::string GetExtension(const std::string &mime_type);
+
 std::string GetFileExtensionInLowerCase(const std::string &filename);
 
 std::string GetFileNameWithoutExtension(const std::string &filename);


### PR DESCRIPTION
Fixing a bug I found where saving out a data pass through texture in geometry::TriangleMesh as a gltf file with external texture files would save the texture files out with the correct format as specified by the mime type, but always with a jpg extension.