### PR TITLE
Make more imported gltf models able to survive round-tripping through open3d

### DIFF
--- a/open3d/geometry/TriangleMesh.cpp
+++ b/open3d/geometry/TriangleMesh.cpp
@@ -55,6 +55,7 @@ TriangleMesh &TriangleMesh::Clear() {
   triangle_normals_.clear();
   adjacency_list_.clear();
   triangle_uvs_.clear();
+  triangles_uvs_idx_.clear();
   materials_.clear();
   triangle_material_ids_.clear();
   textures_.clear();

--- a/open3d/geometry/TriangleMesh.cpp
+++ b/open3d/geometry/TriangleMesh.cpp
@@ -1583,7 +1583,7 @@ std::unordered_map<Eigen::Vector2i, double, utility::hash_eigen<Eigen::Vector2i>
 
 bool TriangleMesh::Material::IsTextured() const {
   return ((bool)albedo || (bool)normalMap || (bool)ambientOcclusion || (bool)metallic || (bool)roughness || (bool)reflectance || (bool)clearCoat ||
-          (bool)clearCoatRoughness || (bool)anisotropy || gltfExtras.texture_idx.has_value());
+          (bool)clearCoatRoughness || (bool)anisotropy || gltfExtras.texture_idx.has_value() || !gltfExtras.extensions.empty());
 }
 
 bool TriangleMesh::Material::MaterialParameter::operator<(const MaterialParameter &other) const {

--- a/open3d/geometry/TriangleMesh.cpp
+++ b/open3d/geometry/TriangleMesh.cpp
@@ -77,13 +77,16 @@ TriangleMesh &TriangleMesh::Rotate(const Eigen::Matrix3d &R, const Eigen::Vector
 }
 
 TriangleMesh &TriangleMesh::operator+=(const TriangleMesh &mesh) {
+  return Add(mesh, true);
+}
+
+TriangleMesh &TriangleMesh::Add(const TriangleMesh &mesh, bool update_triangle_material_ids) {
   if (mesh.IsEmpty())
     return (*this);
   if (IsEmpty()) {
     *this = mesh;
     return (*this);
   }
-  const bool has_textures = mesh.HasTriangleUvs() && mesh.HasTextures() && mesh.HasTriangleMaterialIds();
   const size_t old_vert_num = vertices_.size();
   const size_t old_tri_num = triangles_.size();
   MeshBase::operator+=(mesh);
@@ -105,10 +108,10 @@ TriangleMesh &TriangleMesh::operator+=(const TriangleMesh &mesh) {
     ComputeAdjacencyList();
   }
 
-  int add_triangle_material_ids_ = (int)materials_.size();
-  int add_triangles_uvs_idx_ = triangle_uvs_.size();
+  int add_triangle_material_ids_ = update_triangle_material_ids ? (int)materials_.size() : 0;
+  int add_triangles_uvs_idx_ = (int)triangle_uvs_.size();
   size_t old_tex_num = textures_.size();
-  if (has_textures) {
+  if (mesh.HasTriangleUvs()) {
     size_t old_tri_uv_num = triangle_uvs_.size();
     triangle_uvs_.resize(triangle_uvs_.size() + mesh.triangle_uvs_.size());
     for (size_t i = 0; i < mesh.triangle_uvs_.size(); i++) {

--- a/open3d/geometry/TriangleMesh.h
+++ b/open3d/geometry/TriangleMesh.h
@@ -752,7 +752,7 @@ class TriangleMesh : public MeshBase {
       // References to textures in extensions are replaced by indexes into extension_images.
       tinygltf::ExtensionMap extensions;
       std::vector<Image> extension_images;
-      bool texture_from_specular_glossiness_extension = false;
+      bool texture_from_specular_glossiness_diffuse = false;
 
       bool operator==(const GltfExtras &other) const {
         return (doubleSided == other.doubleSided && alphaMode == other.alphaMode && alphaCutoff == other.alphaCutoff &&

--- a/open3d/geometry/TriangleMesh.h
+++ b/open3d/geometry/TriangleMesh.h
@@ -83,7 +83,7 @@ class TriangleMesh : public MeshBase {
   bool HasAdjacencyList() const { return vertices_.size() > 0 && adjacency_list_.size() == vertices_.size(); }
 
   bool HasTriangleUvs() const {
-    return HasTriangles() && (triangle_uvs_.size() == 3 * triangles_.size() || triangle_uvs_.size() == vertices_.size());
+    return HasTriangles() && !triangle_uvs_.empty();
   }
 
   bool HasTriangleUvs_Any() const {
@@ -94,7 +94,7 @@ class TriangleMesh : public MeshBase {
       valid_uv = true;
       break;
     }
-    return HasTriangles() && valid_uv && triangles_uvs_idx_.size() == triangles_.size() && !triangle_uvs_.empty();
+    return HasTriangles() && valid_uv && !triangle_uvs_.empty();
   }
 
   bool HasTriangleUvIndices() const { return (!triangles_uvs_idx_.empty()); }

--- a/open3d/geometry/TriangleMesh.h
+++ b/open3d/geometry/TriangleMesh.h
@@ -72,6 +72,7 @@ class TriangleMesh : public MeshBase {
   virtual TriangleMesh &Rotate(const Eigen::Matrix3d &R, const Eigen::Vector3d &center) override;
 
  public:
+  TriangleMesh &Add(const TriangleMesh &mesh, bool update_triangle_material_ids = true);
   TriangleMesh &operator+=(const TriangleMesh &mesh);
   TriangleMesh operator+(const TriangleMesh &mesh) const;
 

--- a/open3d/geometry/TriangleMesh.h
+++ b/open3d/geometry/TriangleMesh.h
@@ -30,6 +30,7 @@
 #include <map>
 #include <memory>
 #include <numeric>
+#include <tiny_gltf.h>
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>
@@ -748,6 +749,10 @@ class TriangleMesh : public MeshBase {
       double alphaCutoff = 0.5;
       std::optional<Eigen::Vector3d> emissiveFactor;
       std::optional<unsigned int> texture_idx;  // If this material should point to a texture, provide the idx (index into TriangleMesh::textures_).
+      // References to textures in extensions are replaced by indexes into extension_images.
+      tinygltf::ExtensionMap extensions;
+      std::vector<Image> extension_images;
+      bool texture_from_specular_glossiness_extension = false;
 
       bool operator==(const GltfExtras &other) const {
         return (doubleSided == other.doubleSided && alphaMode == other.alphaMode && alphaCutoff == other.alphaCutoff &&


### PR DESCRIPTION
- fix some issues with meshes that have materials but no uvs (because the material just has a solid color)
- support materials that have a `KHR_materials_pbrSpecularGlossiness` `diffuseTexture` instead of a `pbrMetallicRoughness` `baseColorTexture`
- for files with a node hierarchy, combine transformations from ancestor nodes instead of only looking at transformations on the leaf nodes
- read in `metallicFactor` and `roughnessFactor` from `pbrMetallicRoughness`
- store gltf extensions for materials in `GltfExtras` and write them back out when saving, including any texture images they reference
- if there are multiple mesh that reference a material, only read in that material once