### PR TITLE
Omri/referenced textures

### DIFF
--- a/open3d/geometry/Reorganization.cpp
+++ b/open3d/geometry/Reorganization.cpp
@@ -415,11 +415,6 @@ static std::vector<TriangleMesh> SeparateMeshByMaterial(const TriangleMesh &mesh
 
     // Add the material.
     single_material_mesh.materials_.push_back(material);
-    if (material.gltfExtras.texture_idx.has_value()) {
-      assert(*material.gltfExtras.texture_idx < mesh.textures_.size());
-      single_material_mesh.materials_.begin()->gltfExtras.texture_idx = 0u;
-      single_material_mesh.textures_.push_back(mesh.textures_[*material.gltfExtras.texture_idx]);
-    }
 
     single_material_meshes.push_back(std::move(single_material_mesh));
   }

--- a/open3d/geometry/Reorganization.cpp
+++ b/open3d/geometry/Reorganization.cpp
@@ -463,8 +463,14 @@ void MakeEffectiveMaterials(TriangleMesh &mesh) {
 }
 
 bool IsTextureInUse(unsigned int texture, const std::vector<TriangleMesh::Material> &materials) {
-  return (std::any_of(materials.begin(), materials.end(),
-                      [&](const TriangleMesh::Material &material) { return (material.gltfExtras.texture_idx == texture); }));
+  return (std::any_of(materials.begin(), materials.end(), [&](const TriangleMesh::Material &material) {
+    return (material.gltfExtras.texture_idx == texture || material.albedo == texture || material.normalMap == texture ||
+            material.ambientOcclusion == texture || material.metallic == texture || material.roughness == texture ||
+            material.reflectance == texture || material.clearCoat == texture || material.clearCoatRoughness == texture ||
+            material.anisotropy == texture || material.gltfExtras.emissiveTexture == texture ||
+            std::find(material.gltfExtras.extension_images.begin(), material.gltfExtras.extension_images.end(), texture) !=
+                material.gltfExtras.extension_images.end());
+  }));
 }
 
 void ConvertTriangleUvUsage(TriangleMesh &mesh, TriangleMesh::TriangleUvUsage usage) {

--- a/open3d/geometry/Reorganization.h
+++ b/open3d/geometry/Reorganization.h
@@ -58,9 +58,11 @@ MaterialsTriangleUsageWithInvalids GetMaterialsTriangleUsageWithUnassigneds(cons
 MaterialsTriangleUsageWithInvalids GetMaterialsTriangleUsageWithUnassigneds(const TriangleMesh &mesh, const DuplicateConsolidation &consolidation);
 
 //! @returns A vector of meshes, each containing just 1 material from the original mesh.
+//! @note textures_ of the returned meshes isn't populated and the texture indices in the returned materials_ reference the original mesh.textures_.
 std::vector<TriangleMesh> SeparateMeshByMaterial(const TriangleMesh &mesh);
 //! @returns A vector of meshes, each containing just 1 material from the original mesh.
 //! @pre consolidation must have been created by GetMaterialConsolidation() on mesh.
+//! @note textures_ of the returned meshes isn't populated and the texture indices in the returned materials_ reference the original mesh.textures_.
 std::vector<TriangleMesh> SeparateMeshByMaterial(const TriangleMesh &mesh, const DuplicateConsolidation &material_consolidation);
 
 //! @returns On meshes that have no materials but have textures, returns materials referencing these textures. Returns mesh.materials_ otherwise.

--- a/open3d/geometry/TriangleMesh.cpp
+++ b/open3d/geometry/TriangleMesh.cpp
@@ -164,8 +164,8 @@ TriangleMesh &TriangleMesh::Add(const TriangleMesh &mesh, bool update_triangle_m
     update_texture_index(materials_.back().anisotropy);
     update_texture_index(materials_.back().gltfExtras.emissiveTexture);
     update_texture_index(materials_.back().gltfExtras.texture_idx);
-    for (auto &extension_image : materials_.back().extension_images) {
-      update_texture_index(extension_image)
+    for (auto &extension_image : materials_.back().gltfExtras.extension_images) {
+      update_texture_index(extension_image);
     }
   }
 
@@ -1666,7 +1666,7 @@ bool TriangleMesh::Material::IsEqualIgnoringName(const Material &other) const {
           baseClearCoatRoughness == other.baseClearCoatRoughness && baseAnisotropy == other.baseAnisotropy && albedo == other.albedo &&
           normalMap == other.normalMap && ambientOcclusion == other.ambientOcclusion && metallic == other.metallic && roughness == other.roughness &&
           reflectance == other.reflectance && clearCoat == other.clearCoat && clearCoatRoughness == other.clearCoatRoughness &&
-          anisotropy == other.anisotropy.get());
+          anisotropy == other.anisotropy);
 }
 
 bool TriangleMesh::Material::IsBeforeIgnoringName(const Material &other) const {
@@ -1695,32 +1695,32 @@ bool TriangleMesh::Material::IsBeforeIgnoringName(const Material &other) const {
     return (baseAnisotropy < other.baseAnisotropy);
   }
 
-  if (albedo != other.albedo.get()) {
-    return (albedo < other.albedo.get());
+  if (albedo != other.albedo) {
+    return (albedo < other.albedo);
   }
-  if (normalMap != other.normalMap.get()) {
-    return (normalMap < other.normalMap.get());
+  if (normalMap != other.normalMap) {
+    return (normalMap < other.normalMap);
   }
-  if (ambientOcclusion != other.ambientOcclusion.get()) {
-    return (ambientOcclusion < other.ambientOcclusion.get());
+  if (ambientOcclusion != other.ambientOcclusion) {
+    return (ambientOcclusion < other.ambientOcclusion);
   }
-  if (metallic != other.metallic.get()) {
-    return (metallic < other.metallic.get());
+  if (metallic != other.metallic) {
+    return (metallic < other.metallic);
   }
-  if (roughness != other.roughness.get()) {
-    return (roughness < other.roughness.get());
+  if (roughness != other.roughness) {
+    return (roughness < other.roughness);
   }
-  if (reflectance != other.reflectance.get()) {
-    return (reflectance < other.reflectance.get());
+  if (reflectance != other.reflectance) {
+    return (reflectance < other.reflectance);
   }
-  if (clearCoat != other.clearCoat.get()) {
-    return (clearCoat < other.clearCoat.get());
+  if (clearCoat != other.clearCoat) {
+    return (clearCoat < other.clearCoat);
   }
-  if (clearCoatRoughness != other.clearCoatRoughness.get()) {
-    return (clearCoatRoughness < other.clearCoatRoughness.get());
+  if (clearCoatRoughness != other.clearCoatRoughness) {
+    return (clearCoatRoughness < other.clearCoatRoughness);
   }
-  if (anisotropy != other.anisotropy.get()) {
-    return (anisotropy < other.anisotropy.get());
+  if (anisotropy != other.anisotropy) {
+    return (anisotropy < other.anisotropy);
   }
   return (false);
 }

--- a/open3d/geometry/TriangleMesh.cpp
+++ b/open3d/geometry/TriangleMesh.cpp
@@ -1598,9 +1598,24 @@ std::unordered_map<Eigen::Vector2i, double, utility::hash_eigen<Eigen::Vector2i>
 }
 
 bool TriangleMesh::Material::IsTextured() const {
-  return ((bool)albedo || (bool)normalMap || (bool)ambientOcclusion || (bool)metallic || (bool)roughness || (bool)reflectance || (bool)clearCoat ||
-          (bool)clearCoatRoughness || (bool)anisotropy || gltfExtras.texture_idx.has_value() || (bool)gltfExtras.emissiveTexture ||
-          !gltfExtras.extension_images.empty());
+  return (albedo.has_value() || normalMap.has_value() || ambientOcclusion.has_value() || metallic.has_value() || roughness.has_value() ||
+          reflectance.has_value() || clearCoat.has_value() || clearCoatRoughness.has_value() || anisotropy.has_value() ||
+          gltfExtras.texture_idx.has_value() || gltfExtras.emissiveTexture.has_value() || !gltfExtras.extension_images.empty());
+}
+
+void TriangleMesh::Material::RemoveTextures() {
+  albedo.reset();
+  normalMap.reset();
+  ambientOcclusion.reset();
+  metallic.reset();
+  roughness.reset();
+  reflectance.reset();
+  clearCoat.reset();
+  clearCoatRoughness.reset();
+  anisotropy.reset();
+  gltfExtras.texture_idx.reset();
+  gltfExtras.emissiveTexture.reset();
+  gltfExtras.extension_images.clear();
 }
 
 bool TriangleMesh::Material::HasBaseClearCoat() const { return (baseClearCoat != 0.0f || baseClearCoatRoughness != 0.0f); }

--- a/open3d/geometry/TriangleMesh.cpp
+++ b/open3d/geometry/TriangleMesh.cpp
@@ -165,7 +165,7 @@ TriangleMesh &TriangleMesh::Add(const TriangleMesh &mesh, bool update_triangle_m
     update_texture_index(materials_.back().gltfExtras.emissiveTexture);
     update_texture_index(materials_.back().gltfExtras.texture_idx);
     for (auto &extension_image : materials_.back().gltfExtras.extension_images) {
-      update_texture_index(extension_image);
+      extension_image += old_tex_num;
     }
   }
 

--- a/open3d/geometry/TriangleMesh.cpp
+++ b/open3d/geometry/TriangleMesh.cpp
@@ -1603,6 +1603,8 @@ bool TriangleMesh::Material::IsTextured() const {
           !gltfExtras.extension_images.empty());
 }
 
+bool TriangleMesh::Material::HasBaseClearCoat() const { return (baseClearCoat != 0.0f || baseClearCoatRoughness != 0.0f); }
+
 bool TriangleMesh::Material::MaterialParameter::operator<(const MaterialParameter &other) const {
   for (auto index = 0u; index < 4u; ++index) {
     if (f4[index] != other.f4[index]) {

--- a/open3d/geometry/TriangleMesh.cpp
+++ b/open3d/geometry/TriangleMesh.cpp
@@ -145,12 +145,27 @@ TriangleMesh &TriangleMesh::Add(const TriangleMesh &mesh, bool update_triangle_m
     }
   }
 
+  auto update_texture_index = [old_tex_num](std::optional<unsigned int> &texture_index) {
+    if (texture_index.has_value()) {
+      *texture_index += old_tex_num;
+    }
+  };
   materials_.reserve(materials_.size() + mesh.materials_.size());
   for (const auto &material : mesh.materials_) {
     materials_.push_back(material);
-    auto &texture_idx = materials_.back().gltfExtras.texture_idx;
-    if (texture_idx.has_value()) {
-      *texture_idx += old_tex_num;
+    update_texture_index(materials_.back().albedo);
+    update_texture_index(materials_.back().normalMap);
+    update_texture_index(materials_.back().ambientOcclusion);
+    update_texture_index(materials_.back().metallic);
+    update_texture_index(materials_.back().roughness);
+    update_texture_index(materials_.back().reflectance);
+    update_texture_index(materials_.back().clearCoat);
+    update_texture_index(materials_.back().clearCoatRoughness);
+    update_texture_index(materials_.back().anisotropy);
+    update_texture_index(materials_.back().gltfExtras.emissiveTexture);
+    update_texture_index(materials_.back().gltfExtras.texture_idx);
+    for (auto &extension_image : materials_.back().extension_images) {
+      update_texture_index(extension_image)
     }
   }
 
@@ -1623,6 +1638,16 @@ bool TriangleMesh::Material::GltfExtras::operator<(const GltfExtras &other) cons
   if (texture_idx != other.texture_idx) {
     return (texture_idx < other.texture_idx);
   }
+  if (extensions != other.extensions) {
+    return (extensions < other.extensions);
+  }
+  if (extension_images != other.extension_images) {
+    return (extension_images < other.extension_images);
+  }
+  if (texture_from_specular_glossiness_diffuse != other.texture_from_specular_glossiness_diffuse) {
+    return (texture_from_specular_glossiness_diffuse < other.texture_from_specular_glossiness_diffuse);
+  }
+
   return (false);
 }
 
@@ -1638,11 +1663,10 @@ bool TriangleMesh::Material::operator<(const Material &other) const {
 bool TriangleMesh::Material::IsEqualIgnoringName(const Material &other) const {
   return (baseColor == other.baseColor && gltfExtras == other.gltfExtras && baseMetallic == other.baseMetallic &&
           baseRoughness == other.baseRoughness && baseReflectance == other.baseReflectance && baseClearCoat == other.baseClearCoat &&
-          baseClearCoatRoughness == other.baseClearCoatRoughness && baseAnisotropy == other.baseAnisotropy && albedo.get() == other.albedo.get() &&
-          normalMap.get() == other.normalMap.get() && ambientOcclusion.get() == other.ambientOcclusion.get() &&
-          metallic.get() == other.metallic.get() && roughness.get() == other.roughness.get() && reflectance.get() == other.reflectance.get() &&
-          clearCoat.get() == other.clearCoat.get() && clearCoatRoughness.get() == other.clearCoatRoughness.get() &&
-          anisotropy.get() == other.anisotropy.get());
+          baseClearCoatRoughness == other.baseClearCoatRoughness && baseAnisotropy == other.baseAnisotropy && albedo == other.albedo &&
+          normalMap == other.normalMap && ambientOcclusion == other.ambientOcclusion && metallic == other.metallic && roughness == other.roughness &&
+          reflectance == other.reflectance && clearCoat == other.clearCoat && clearCoatRoughness == other.clearCoatRoughness &&
+          anisotropy == other.anisotropy.get());
 }
 
 bool TriangleMesh::Material::IsBeforeIgnoringName(const Material &other) const {
@@ -1671,32 +1695,32 @@ bool TriangleMesh::Material::IsBeforeIgnoringName(const Material &other) const {
     return (baseAnisotropy < other.baseAnisotropy);
   }
 
-  if (albedo.get() != other.albedo.get()) {
-    return (albedo.get() < other.albedo.get());
+  if (albedo != other.albedo.get()) {
+    return (albedo < other.albedo.get());
   }
-  if (normalMap.get() != other.normalMap.get()) {
-    return (normalMap.get() < other.normalMap.get());
+  if (normalMap != other.normalMap.get()) {
+    return (normalMap < other.normalMap.get());
   }
-  if (ambientOcclusion.get() != other.ambientOcclusion.get()) {
-    return (ambientOcclusion.get() < other.ambientOcclusion.get());
+  if (ambientOcclusion != other.ambientOcclusion.get()) {
+    return (ambientOcclusion < other.ambientOcclusion.get());
   }
-  if (metallic.get() != other.metallic.get()) {
-    return (metallic.get() < other.metallic.get());
+  if (metallic != other.metallic.get()) {
+    return (metallic < other.metallic.get());
   }
-  if (roughness.get() != other.roughness.get()) {
-    return (roughness.get() < other.roughness.get());
+  if (roughness != other.roughness.get()) {
+    return (roughness < other.roughness.get());
   }
-  if (reflectance.get() != other.reflectance.get()) {
-    return (reflectance.get() < other.reflectance.get());
+  if (reflectance != other.reflectance.get()) {
+    return (reflectance < other.reflectance.get());
   }
-  if (clearCoat.get() != other.clearCoat.get()) {
-    return (clearCoat.get() < other.clearCoat.get());
+  if (clearCoat != other.clearCoat.get()) {
+    return (clearCoat < other.clearCoat.get());
   }
-  if (clearCoatRoughness.get() != other.clearCoatRoughness.get()) {
-    return (clearCoatRoughness.get() < other.clearCoatRoughness.get());
+  if (clearCoatRoughness != other.clearCoatRoughness.get()) {
+    return (clearCoatRoughness < other.clearCoatRoughness.get());
   }
-  if (anisotropy.get() != other.anisotropy.get()) {
-    return (anisotropy.get() < other.anisotropy.get());
+  if (anisotropy != other.anisotropy.get()) {
+    return (anisotropy < other.anisotropy.get());
   }
   return (false);
 }

--- a/open3d/geometry/TriangleMesh.h
+++ b/open3d/geometry/TriangleMesh.h
@@ -26,12 +26,13 @@
 
 #pragma once
 
+#include <tiny_gltf.h>
+
 #include <Eigen/Core>
 #include <map>
 #include <memory>
 #include <numeric>
 #include <optional>
-#include <tiny_gltf.h>
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>
@@ -110,8 +111,7 @@ class TriangleMesh : public MeshBase {
 
   /// Returns `true` if the mesh has texture.
   bool HasTextures() const {
-    bool is_all_texture_valid = std::accumulate(textures_.begin(), textures_.end(), true, [](bool a, const Image &b) { return a && !b.IsEmpty(); });
-    return !textures_.empty() && is_all_texture_valid;
+    return (!textures_.empty() && std::any_of(textures_.begin(), textures_.end(), [](const Image &image) { return (!image.IsEmpty()); }));
   }
 
   bool HasMaterials() const { return !materials_.empty(); }
@@ -739,15 +739,15 @@ class TriangleMesh : public MeshBase {
     float baseClearCoatRoughness = 0.f;
     float baseAnisotropy = 0.f;
 
-    std::shared_ptr<Image> albedo;
-    std::shared_ptr<Image> normalMap;
-    std::shared_ptr<Image> ambientOcclusion;
-    std::shared_ptr<Image> metallic;
-    std::shared_ptr<Image> roughness;
-    std::shared_ptr<Image> reflectance;
-    std::shared_ptr<Image> clearCoat;
-    std::shared_ptr<Image> clearCoatRoughness;
-    std::shared_ptr<Image> anisotropy;
+    std::optional<unsigned int> albedo;              // Indices into textures_.
+    std::optional<unsigned int> normalMap;           // Indices into textures_.
+    std::optional<unsigned int> ambientOcclusion;    // Indices into textures_.
+    std::optional<unsigned int> metallic;            // Indices into textures_.
+    std::optional<unsigned int> roughness;           // Indices into textures_.
+    std::optional<unsigned int> reflectance;         // Indices into textures_.
+    std::optional<unsigned int> clearCoat;           // Indices into textures_.
+    std::optional<unsigned int> clearCoatRoughness;  // Indices into textures_.
+    std::optional<unsigned int> anisotropy;          // Indices into textures_.
 
     // Additional properties added by polycam to more accurately model a gltf/glb material
     // as neccessary for properly round tripping materials for roomplan captures.
@@ -756,16 +756,18 @@ class TriangleMesh : public MeshBase {
       std::string alphaMode = "OPAQUE";
       double alphaCutoff = 0.5;
       std::optional<Eigen::Vector3d> emissiveFactor;
-      std::shared_ptr<Image> emissiveTexture;
-      std::optional<unsigned int> texture_idx;  // If this material should point to a texture, provide the idx (index into TriangleMesh::textures_).
+      std::optional<unsigned int> emissiveTexture;  // Indices into textures_.
+      std::optional<unsigned int> texture_idx;      // Indices into textures_.
       // References to textures in extensions are replaced by indexes into extension_images.
       tinygltf::ExtensionMap extensions;
-      std::vector<Image> extension_images;
+      std::vector<unsigned int> extension_images;  // Indices into textures_.
       bool texture_from_specular_glossiness_diffuse = false;
 
       bool operator==(const GltfExtras &other) const {
         return (doubleSided == other.doubleSided && alphaMode == other.alphaMode && alphaCutoff == other.alphaCutoff &&
-                emissiveFactor == other.emissiveFactor && emissiveTexture == other.emissiveTexture && texture_idx == other.texture_idx);
+                emissiveFactor == other.emissiveFactor && emissiveTexture == other.emissiveTexture && texture_idx == other.texture_idx &&
+                extensions == other.extensions && extension_images == other.extension_images &&
+                texture_from_specular_glossiness_diffuse == other.texture_from_specular_glossiness_diffuse);
       }
 
       bool operator!=(const GltfExtras &other) const { return (!(*this == other)); }

--- a/open3d/geometry/TriangleMesh.h
+++ b/open3d/geometry/TriangleMesh.h
@@ -676,6 +676,7 @@ class TriangleMesh : public MeshBase {
 
   struct Material {
     bool IsTextured() const;
+    bool HasBaseClearCoat() const;
 
     struct MaterialParameter {
       float f4[4] = {0};

--- a/open3d/geometry/TriangleMesh.h
+++ b/open3d/geometry/TriangleMesh.h
@@ -676,6 +676,7 @@ class TriangleMesh : public MeshBase {
 
   struct Material {
     bool IsTextured() const;
+    void RemoveTextures();
     bool HasBaseClearCoat() const;
 
     struct MaterialParameter {

--- a/open3d/io/file_format/FileGLTF.cpp
+++ b/open3d/io/file_format/FileGLTF.cpp
@@ -290,13 +290,13 @@ static Eigen::Matrix3d GetTextureTransformation(const tinygltf::Value::Object &o
   if (rotation.has_value()) {
     const auto sine = std::sin(*rotation);
     const auto cosine = std::cos(*rotation);
-    auto rotation_transformation = Eigen::Matrix3d();
+    Eigen::Matrix3d rotation_transformation;
     rotation_transformation << cosine, sine, 0.0, -sine, cosine, 0.0, 0.0, 0.0, 1.0;
     transformation = transformation * rotation_transformation;
   }
   const auto scale = GetVector2Child(object, "scale");
   if (scale.has_value()) {
-    const auto scale_transformation = Eigen::Matrix3d();
+    Eigen::Matrix3d scale_transformation;
     scale_transformation << (*scale)(0u), 0.0, 0.0, 0.0, (*scale)(1u), 0.0, 0.0, 0.0, 1.0;
     transformation = transformation * scale_transformation;
   }

--- a/open3d/io/file_format/FileGLTF.cpp
+++ b/open3d/io/file_format/FileGLTF.cpp
@@ -665,11 +665,12 @@ bool SaveMeshGLTF(const std::string &fileName, const geometry::TriangleMesh &_me
   tinygltf::Buffer gltfBuffer;
 
   if (_mesh.HasTextures()) {
-    const auto parent_directory = std::filesystem::path(fileName).parent_path();
+    const auto file_path = std::filesystem::path(fileName);
+    const auto parent_directory = file_path.parent_path();
     const auto assets_relative_directory = std::filesystem::path("assets");
     const auto assets_directory = parent_directory / assets_relative_directory;
     std::filesystem::create_directories(assets_directory);
-    const auto texture_base_name = utility::filesystem::GetFileNameWithoutExtension(fileName);
+    const auto texture_base_name = file_path.stem().string();
     gltfModel.images.reserve(_mesh.textures_.size());
     gltfModel.textures.reserve(_mesh.textures_.size());
     for (auto texture_index = 0u; texture_index < _mesh.textures_.size(); ++texture_index) {

--- a/open3d/io/file_format/FileGLTF.cpp
+++ b/open3d/io/file_format/FileGLTF.cpp
@@ -695,7 +695,7 @@ bool SaveMeshGLTF(const std::string &fileName, const geometry::TriangleMesh &_me
           tinygltf::Image gltf_image;
           gltf_image.name = texture_name;
           const auto *encoded_data = image.pass_through_.has_value() ? std::get_if<geometry::Image::EncodedData>(&*image.pass_through_)
-                                                                     : (const std::filesystem::path *)nullptr;
+                                                                     : (const geometry::Image::EncodedData *)nullptr;
           const auto mime_type = ((encoded_data != nullptr) ? encoded_data->mime_type_.c_str() : "image/jpeg");
           gltf_image.mimeType = mime_type;
           const auto relative_texture_file =

--- a/open3d/io/file_format/FileGLTF.cpp
+++ b/open3d/io/file_format/FileGLTF.cpp
@@ -284,19 +284,21 @@ static Eigen::Matrix3d GetTextureTransformation(const tinygltf::Value::Object &o
   auto transformation = Eigen::Matrix3d::Identity();
   const auto translation = GetVector2Child(object, "offset");
   if (translation.has_value()) {
-    transformation.row(2u) << translation(0u), translation(1u), 1.0;
+    transformation.row(2u) << (*translation)(0u), (*translation)(1u), 1.0;
   }
   const auto rotation = GetDoubleChild(object, "rotation");
   if (rotation.has_value()) {
     const auto sine = std::sin(*rotation);
     const auto cosine = std::cos(*rotation);
-    const auto rotation_transformation = Eigen::Matrix3d(cosine, sine, 0.0, -sine, cosine, 0.0, 0.0, 0.0, 1.0);
-    transformation = Eigen::Matrix3d(transformation * rotation_transformation);
+    auto rotation_transformation = Eigen::Matrix3d();
+    rotation_transformation << cosine, sine, 0.0, -sine, cosine, 0.0, 0.0, 0.0, 1.0;
+    transformation = transformation * rotation_transformation;
   }
   const auto scale = GetVector2Child(object, "scale");
   if (scale.has_value()) {
-    const auto scale_transformation = Eigen::Matrix3d((*scale)(0u), 0.0, 0.0, 0.0, (*scale)(1u), 0.0, 0.0, 0.0, 1.0);
-    transformation = Eigen::Matrix3d(transformation * scale_transformation);
+    const auto scale_transformation = Eigen::Matrix3d();
+    scale_transformation << (*scale)(0u), 0.0, 0.0, 0.0, (*scale)(1u), 0.0, 0.0, 0.0, 1.0;
+    transformation = transformation * scale_transformation;
   }
   return (transformation);
 }

--- a/open3d/io/file_format/FileGLTF.cpp
+++ b/open3d/io/file_format/FileGLTF.cpp
@@ -347,12 +347,13 @@ bool ReadTriangleMeshFromGLTFWithOptions(const std::string &filename, geometry::
     material.baseRoughness = gltf_material.pbrMetallicRoughness.roughnessFactor;
     auto base_texture_info = tinygltf::TextureInfo();
     if (gltf_material.pbrMetallicRoughness.baseColorTexture.index >= 0) {
-      base_texture_info.index = gltf_material.pbrMetallicRoughness.baseColorTexture.index;
+      base_texture_info = gltf_material.pbrMetallicRoughness.baseColorTexture;
     } else if (const auto it = gltf_material.extensions.find(specular_glossiness_extension); it != gltf_material.extensions.end()) {
       const auto &specularGlossiness = it->second;
       // Treat the diffuse texture as the base color texture.
       if (specularGlossiness.Has("diffuseTexture")) {
         base_texture_info.index = specularGlossiness.Get("diffuseTexture").Get("index").Get<int>();
+        base_texture_info.texCoord = specularGlossiness.Get("diffuseTexture").Get("texCoord").Get<int>();
         material.gltfExtras.texture_from_specular_glossiness_diffuse = true;
       }
     }

--- a/open3d/io/file_format/FileGLTF.cpp
+++ b/open3d/io/file_format/FileGLTF.cpp
@@ -1,3 +1,5 @@
+#if false
+
 // ----------------------------------------------------------------------------
 // -                        Open3D: www.open3d.org                            -
 // ----------------------------------------------------------------------------
@@ -1328,3 +1330,5 @@ bool WriteTriangleMeshToGLTF(const std::string &filename, const geometry::Triang
 
 }  // namespace io
 }  // namespace open3d
+
+#endif

--- a/open3d/io/file_format/FileGLTF.cpp
+++ b/open3d/io/file_format/FileGLTF.cpp
@@ -281,7 +281,7 @@ static std::optional<double> GetDoubleChild(const tinygltf::Value::Object &objec
 }
 
 static Eigen::Matrix3d GetTextureTransformation(const tinygltf::Value::Object &object) {
-  auto transformation = Eigen::Matrix3d::Identity();
+  Eigen::Matrix3d transformation = Eigen::Matrix3d::Identity();
   const auto translation = GetVector2Child(object, "offset");
   if (translation.has_value()) {
     transformation.row(2u) << (*translation)(0u), (*translation)(1u), 1.0;

--- a/open3d/io/file_format/FileGLTF.cpp
+++ b/open3d/io/file_format/FileGLTF.cpp
@@ -252,21 +252,21 @@ bool LoadImageData(tinygltf::Image *gltf_image, const int image_idx, std::string
 
 FileGeometry ReadFileGeometryTypeGLTF(const std::string &path) { return FileGeometry(CONTAINS_TRIANGLES | CONTAINS_POINTS); }
 
-static std::optional<Eigen::Vector2> GetVector2Child(const tinygltf::Value::Object &object, const char *child_name) {
+static std::optional<Eigen::Vector2d> GetVector2Child(const tinygltf::Value::Object &object, const char *child_name) {
   const auto child = object.find(child_name);
   if (child == object.end()) {
-    return (std::optional<Eigen::Vector2>());
+    return (std::optional<Eigen::Vector2d>());
   }
   if (!child->second.IsArray()) {
-    return (std::optional<Eigen::Vector2>());
+    return (std::optional<Eigen::Vector2d>());
   }
   if (child->second.ArrayLen() != 2u) {
-    return (std::optional<Eigen::Vector2>());
+    return (std::optional<Eigen::Vector2d>());
   }
   if (!child->second.Get(0u).IsNumber() || child->second.Get(1u).IsNumber()) {
-    return (std::optional<Eigen::Vector2>());
+    return (std::optional<Eigen::Vector2d>());
   }
-  return (Eigen::Vector2{child->second.Get(0u).GetNumberAsDouble(), child->second.Get(1u).GetNumberAsDouble()});
+  return (Eigen::Vector2d{child->second.Get(0u).GetNumberAsDouble(), child->second.Get(1u).GetNumberAsDouble()});
 }
 
 static std::optional<double> GetDoubleChild(const tinygltf::Value::Object &object, const char *child_name) {
@@ -291,12 +291,12 @@ static Eigen::Matrix3d GetTextureTransformation(const tinygltf::Value::Object &o
     const auto sine = std::sin(*rotation);
     const auto cosine = std::cos(*rotation);
     const auto rotation_transformation = Eigen::Matrix3d(cosine, sine, 0.0, -sine, cosine, 0.0, 0.0, 0.0, 1.0);
-    transformation = transformation * rotation_transformation;
+    transformation = Eigen::Matrix3d(transformation * rotation_transformation);
   }
   const auto scale = GetVector2Child(object, "scale");
   if (scale.has_value()) {
     const auto scale_transformation = Eigen::Matrix3d((*scale)(0u), 0.0, 0.0, 0.0, (*scale)(1u), 0.0, 0.0, 0.0, 1.0);
-    transformation = transformation * scale_transformation;
+    transformation = Eigen::Matrix3d(transformation * scale_transformation);
   }
   return (transformation);
 }

--- a/open3d/io/file_format/FileGLTF.cpp
+++ b/open3d/io/file_format/FileGLTF.cpp
@@ -813,7 +813,7 @@ bool SaveMeshGLTF(const std::string &fileName, const geometry::TriangleMesh &_me
     InitializeGltfMaterial(gltfMaterial, mesh);
     gltfPrimitive.material = gltfModel.materials.size();
     gltfMaterial.extensions = material.gltfExtras.extensions;
-    if (material.baseClearCoat != 0.0f || material.baseClearCoatRoughness != 0.0f) {
+    if (material.HasBaseClearCoat()) {
       auto object = tinygltf::Value::Object();
       object.insert(std::make_pair(clear_coat_extension_factor_key, tinygltf::Value((double)material.baseClearCoat)));
       object.insert(std::make_pair(clear_coat_extension_roughness_factor_key, tinygltf::Value((double)material.baseClearCoatRoughness)));

--- a/open3d/io/file_format/FileGLTF.cpp
+++ b/open3d/io/file_format/FileGLTF.cpp
@@ -675,30 +675,39 @@ bool SaveMeshGLTF(const std::string &fileName, const geometry::TriangleMesh &_me
     gltfModel.textures.reserve(_mesh.textures_.size());
     for (auto texture_index = 0u; texture_index < _mesh.textures_.size(); ++texture_index) {
       const auto &image = _mesh.textures_[texture_index];
-      auto skipped_external_texture = TrySkippedExternalTexture(image, parent_directory);
-      if (skipped_external_texture.has_value()) {
-        gltfModel.images.push_back(std::move(*skipped_external_texture));
-      } else {
+      if (bBinary) {
         const auto encoded_data = EncodeImage(image, path + "Temp.jpg");
         tinygltf::Image gltf_image;
         gltf_image.mimeType = encoded_data.mime_type_;
-        if (bBinary) {
-          gltf_image.bufferView = gltfModel.bufferViews.size();
-          gltf_image.as_is = true;
-          tinygltf::BufferView imageBufferView;
-          imageBufferView.buffer = gltfModel.buffers.size();
-          extendBuffer(encoded_data.data_, gltfBuffer, imageBufferView.byteOffset, imageBufferView.byteLength);
-          gltfModel.bufferViews.emplace_back(std::move(imageBufferView));
-          gltfModel.images.emplace_back(std::move(gltf_image));
+        gltf_image.bufferView = gltfModel.bufferViews.size();
+        gltf_image.as_is = true;
+        tinygltf::BufferView imageBufferView;
+        imageBufferView.buffer = gltfModel.buffers.size();
+        extendBuffer(encoded_data.data_, gltfBuffer, imageBufferView.byteOffset, imageBufferView.byteLength);
+        gltfModel.bufferViews.emplace_back(std::move(imageBufferView));
+        gltfModel.images.emplace_back(std::move(gltf_image));
+      } else {
+        auto skipped_external_texture = TrySkippedExternalTexture(image, parent_directory);
+        if (skipped_external_texture.has_value()) {
+          gltfModel.images.push_back(std::move(*skipped_external_texture));
         } else {
           const auto texture_name = texture_base_name + '_' + std::to_string(texture_index);
+          tinygltf::Image gltf_image;
           gltf_image.name = texture_name;
+          const auto *encoded_data =
+              image.pass_through_.has_value() ? std::get_if<std::filesystem::path>(&*image.pass_through_) : (const std::filesystem::path *)nullptr;
+          const auto mime_type = ((encoded_data != nullptr) ? encoded_data->mime_type_.c_str() : "image/jpeg");
+          gltf_image.mimeType = mime_type;
           const auto relative_texture_file =
-              assets_relative_directory / std::filesystem::path(texture_name + '.' + utility::filesystem::GetExtension(encoded_data.mime_type_));
+              assets_relative_directory / std::filesystem::path(texture_name + '.' + utility::filesystem::GetExtension(mime_type));
           const auto texture_file = parent_directory / relative_texture_file;
           gltf_image.uri = relative_texture_file.string();
           std::filesystem::remove(texture_file);
-          WriteFileFromBuffer(texture_file.string(), encoded_data.data_);
+          if (encoded_data != nullptr) {
+            WriteFileFromBuffer(texture_file.string(), encoded_data->data_);
+          } else {
+            io::WriteImage(texture_file.string(), image);
+          }
           gltfModel.images.emplace_back(std::move(gltf_image));
         }
       }

--- a/open3d/io/file_format/FileGLTF.cpp
+++ b/open3d/io/file_format/FileGLTF.cpp
@@ -694,8 +694,8 @@ bool SaveMeshGLTF(const std::string &fileName, const geometry::TriangleMesh &_me
           const auto texture_name = texture_base_name + '_' + std::to_string(texture_index);
           tinygltf::Image gltf_image;
           gltf_image.name = texture_name;
-          const auto *encoded_data =
-              image.pass_through_.has_value() ? std::get_if<std::filesystem::path>(&*image.pass_through_) : (const std::filesystem::path *)nullptr;
+          const auto *encoded_data = image.pass_through_.has_value() ? std::get_if<geometry::Image::EncodedData>(&*image.pass_through_)
+                                                                     : (const std::filesystem::path *)nullptr;
           const auto mime_type = ((encoded_data != nullptr) ? encoded_data->mime_type_.c_str() : "image/jpeg");
           gltf_image.mimeType = mime_type;
           const auto relative_texture_file =

--- a/open3d/io/file_format/FileGLTF.cpp
+++ b/open3d/io/file_format/FileGLTF.cpp
@@ -670,6 +670,8 @@ bool SaveMeshGLTF(const std::string &fileName, const geometry::TriangleMesh &_me
     const auto assets_directory = parent_directory / assets_relative_directory;
     std::filesystem::create_directories(assets_directory);
     const auto texture_base_name = utility::filesystem::GetFileNameWithoutExtension(fileName);
+    gltfModel.images.reserve(_mesh.textures_.size());
+    gltfModel.textures.reserve(_mesh.textures_.size());
     for (auto texture_index = 0u; texture_index < _mesh.textures_.size(); ++texture_index) {
       const auto &image = _mesh.textures_[texture_index];
       auto skipped_external_texture = TrySkippedExternalTexture(image, parent_directory);
@@ -699,6 +701,9 @@ bool SaveMeshGLTF(const std::string &fileName, const geometry::TriangleMesh &_me
           gltfModel.images.emplace_back(std::move(gltf_image));
         }
       }
+      tinygltf::Texture gltf_texture;
+      gltf_texture.source = gltfModel.textures.size();
+      gltfModel.textures.emplace_back(std::move(gltf_texture));
     }
   }
 
@@ -798,6 +803,7 @@ bool SaveMeshGLTF(const std::string &fileName, const geometry::TriangleMesh &_me
           texture_info.texCoord = 0;
         }
       };
+
       setup_texture_if_needed(material.gltfExtras.texture_idx.has_value() ? material.gltfExtras.texture_idx : material.albedo,
                               gltfMaterial.pbrMetallicRoughness.baseColorTexture);
       setup_texture_if_needed(material.normalMap, gltfMaterial.normalTexture);

--- a/open3d/io/file_format/FileGLTF.cpp
+++ b/open3d/io/file_format/FileGLTF.cpp
@@ -656,6 +656,13 @@ bool ReadTriangleMeshFromGLTFWithOptions(const std::string &filename, geometry::
           mesh_temp.triangles_uvs_idx_ = std::vector<Eigen::Vector3i>(mesh_temp.triangles_.size(), Eigen::Vector3i::Constant(-1));
         }
 
+        // handle invalid meshes with a texture but no texture coordinates by skipping texturing altogether
+        if (materials[material_id].material_.IsTextured() &&
+            (texture_coordinates_attribute.has_value() ? primitive.attributes.find(*texture_coordinates_attribute) == primitive.attributes.end()
+                                                       : true)) {
+          materials[material_id].material_.RemoveTextures();
+        }
+
         // read textures
         mesh_temp.triangle_material_ids_.resize(mesh_temp.triangles_.size(), (int)material_id);
         if (materials[material_id].material_.IsTextured()) {

--- a/open3d/io/file_format/FileGLTF.cpp
+++ b/open3d/io/file_format/FileGLTF.cpp
@@ -364,7 +364,8 @@ bool ReadTriangleMeshFromGLTFWithOptions(const std::string &filename, geometry::
         const auto texture_transformation_extension = tiny_gltf_texture.extensions.find("KHR_texture_transform");
         if (texture_transformation_extension != tiny_gltf_texture.extensions.end()) {
           if (texture_transformation_extension->second.IsObject()) {
-            specific_texture_transformation = GetTextureTransformation(texture_transformation_extension->second.Get<tinygltf::Value::Object>());
+            specific_texture_transformation =
+                GetTextureTransformation(texture_transformation_extension->second.template Get<tinygltf::Value::Object>());
           }
         }
         if (texture_transformation.has_value()) {
@@ -466,7 +467,7 @@ bool ReadTriangleMeshFromGLTFWithOptions(const std::string &filename, geometry::
             auto extra_texture_info = tinygltf::TextureInfo();
             extra_texture_info.index = index_value.GetNumberAsInt();
             auto open3d_texture = std::optional<unsigned int>();
-            reference_texture_if_needed(open3d_texture, texture_coordinates_index, extra_texture_info);
+            reference_texture_if_needed(open3d_texture, texture_coordinates_index, texture_transformation, extra_texture_info);
             if (open3d_texture.has_value()) {
               index_value = tinygltf::Value((int)material.gltfExtras.extension_images.size());
               material.gltfExtras.extension_images.push_back(*open3d_texture);

--- a/open3d/io/file_format/FileGLTF.cpp
+++ b/open3d/io/file_format/FileGLTF.cpp
@@ -263,7 +263,7 @@ static std::optional<Eigen::Vector2d> GetVector2Child(const tinygltf::Value::Obj
   if (child->second.ArrayLen() != 2u) {
     return (std::optional<Eigen::Vector2d>());
   }
-  if (!child->second.Get(0u).IsNumber() || child->second.Get(1u).IsNumber()) {
+  if (!child->second.Get(0u).IsNumber() || !child->second.Get(1u).IsNumber()) {
     return (std::optional<Eigen::Vector2d>());
   }
   return (Eigen::Vector2d{child->second.Get(0u).GetNumberAsDouble(), child->second.Get(1u).GetNumberAsDouble()});

--- a/open3d/io/file_format/FileGLTF.cpp
+++ b/open3d/io/file_format/FileGLTF.cpp
@@ -668,8 +668,7 @@ bool SaveMeshGLTF(const std::string &fileName, const geometry::TriangleMesh &_me
     const auto file_path = std::filesystem::path(fileName);
     const auto parent_directory = file_path.parent_path();
     const auto assets_relative_directory = std::filesystem::path("assets");
-    const auto assets_directory = parent_directory / assets_relative_directory;
-    std::filesystem::create_directories(assets_directory);
+    auto created_assets_directory = false;
     const auto texture_base_name = file_path.stem().string();
     gltfModel.images.reserve(_mesh.textures_.size());
     gltfModel.textures.reserve(_mesh.textures_.size());
@@ -691,6 +690,11 @@ bool SaveMeshGLTF(const std::string &fileName, const geometry::TriangleMesh &_me
         if (skipped_external_texture.has_value()) {
           gltfModel.images.push_back(std::move(*skipped_external_texture));
         } else {
+          if (!created_assets_directory) {
+            const auto assets_directory = parent_directory / assets_relative_directory;
+            std::filesystem::create_directories(assets_directory);
+            created_assets_directory = true;
+          }
           const auto texture_name = texture_base_name + '_' + std::to_string(texture_index);
           tinygltf::Image gltf_image;
           gltf_image.name = texture_name;

--- a/open3d/io/file_format/FileGLTF.cpp
+++ b/open3d/io/file_format/FileGLTF.cpp
@@ -814,7 +814,7 @@ bool SaveMeshGLTF(const std::string &fileName, const geometry::TriangleMesh &_me
     gltfPrimitive.material = gltfModel.materials.size();
     gltfMaterial.extensions = material.gltfExtras.extensions;
     if (material.baseClearCoat != 0.0f || material.baseClearCoatRoughness != 0.0f) {
-      auto object = tinygltf::Object();
+      auto object = tinygltf::Value::Object();
       object.insert(std::make_pair(clear_coat_extension_factor_key, tinygltf::Value((double)material.baseClearCoat)));
       object.insert(std::make_pair(clear_coat_extension_roughness_factor_key, tinygltf::Value((double)material.baseClearCoatRoughness)));
       gltfMaterial.extensions.insert(std::make_pair(clear_coat_extension, tinygltf::Value(std::move(object))));

--- a/open3d/io/file_format/FileOBJ.cpp
+++ b/open3d/io/file_format/FileOBJ.cpp
@@ -173,7 +173,7 @@ bool ReadTriangleMeshFromOBJ(const std::string &filename, geometry::TriangleMesh
     if (already_loaded_texture != already_loaded_textures.end()) {
       return (std::make_optional(already_loaded_texture->second));
     }
-    const auto absolute_path = mtl_base_path + relativePath;
+    const auto absolute_path = mtl_base_path + relative_path;
     auto image = io::CreateImageFromFile(absolute_path);
     if (!image->HasData()) {
       return (std::optional<unsigned int>());
@@ -181,7 +181,7 @@ bool ReadTriangleMeshFromOBJ(const std::string &filename, geometry::TriangleMesh
     image = image->FlipVertical();
     const auto texture_index = (unsigned int)textures.size();
     already_loaded_textures.insert(std::make_pair(relative_path, texture_index));
-    const auto texture_name = GetFileNameWithoutExtension(GetFileNameWithoutDirectory(relative_path));
+    const auto texture_name = utility::filesystem::GetFileNameWithoutExtension(utility::filesystem::GetFileNameWithoutDirectory(relative_path));
     textures.push_back(std::make_pair(texture_name, std::move(image)));
     return (std::make_optional(texture_index));
   };
@@ -225,9 +225,9 @@ bool ReadTriangleMeshFromOBJ(const std::string &filename, geometry::TriangleMesh
   }
 
   mesh.textures_.reserve(textures.size());
-  mesh.texture_names_.reserve(textures.size()) for (auto &texture : textures) {
+  mesh.textures_names_.reserve(textures.size()); for (auto &texture : textures) {
     mesh.textures_.push_back(std::move(texture.second));
-    mesh.texture_names_.push_back(std::move(texture.first));
+    mesh.textures_names_.push_back(std::move(texture.first));
   }
 
   return true;
@@ -239,12 +239,12 @@ bool WriteTriangleMeshToOBJ(const std::string &filename, const geometry::Triangl
   const auto timer_start = std::chrono::high_resolution_clock::now();
   std::string object_name = utility::filesystem::GetFileNameWithoutExtension(utility::filesystem::GetFileNameWithoutDirectory(filename));
   const auto has_texture_names =
-      (mesh.texture_names_.size() == mesh.textures_.size() && !mesh.texture_names_.empty() &&
-       std::none_of(mesh.texture_names_.begin(), mesh.texture_names_.end(), [](const std::string &texture_name) { return (texture_name.empty()); }));
+      (mesh.textures_names_.size() == mesh.textures_.size() && !mesh.textures_names_.empty() &&
+       std::none_of(mesh.textures_names_.begin(), mesh.textures_names_.end(), [](const std::string &texture_name) { return (texture_name.empty()); }));
   const auto texture_extension = ".jpg";
   const auto random_postfix = random_string(8);
-  const auto get_texture_name = [&](unsigned int texture) {
-    return (has_texture_names ? mesh.texture_names_[texture_index] : object_name + '_' + std::to_string(texture_index) + '_' + random_postfix);
+  const auto get_texture_name = [&](unsigned int texture_index) {
+    return (has_texture_names ? mesh.textures_names_[texture_index] : object_name + '_' + std::to_string(texture_index) + '_' + random_postfix);
   };
   std::string object_name_prefix = object_name + '_';
   const auto triangle_uv_usage = mesh.GetTriangleUvUsage();

--- a/open3d/io/file_format/FileOBJ.cpp
+++ b/open3d/io/file_format/FileOBJ.cpp
@@ -176,10 +176,9 @@ bool ReadTriangleMeshFromOBJ(const std::string &filename, geometry::TriangleMesh
     const auto absolute_path = mtl_base_path + relative_path;
     auto image = geometry::Image();
     io::ReadImage(absolute_path, image);
-    if (!image->HasData()) {
+    if (!image.HasData()) {
       return (std::optional<unsigned int>());
     }
-    image = image->FlipVertical();
     const auto texture_index = (unsigned int)textures.size();
     already_loaded_textures.insert(std::make_pair(relative_path, texture_index));
     const auto texture_name = utility::filesystem::GetFileNameWithoutExtension(utility::filesystem::GetFileNameWithoutDirectory(relative_path));
@@ -447,7 +446,7 @@ bool WriteTriangleMeshToOBJ(const std::string &filename, const geometry::Triangl
 
     auto write_texture = [&](unsigned int texture_index) {
       if (!IsTextureInUse(texture_index, effective_materials))
-        continue;
+        return;
       std::string tex_name = get_texture_name(texture_index);
       std::string tex_filename = parent_dir + tex_name + texture_extension;
 

--- a/open3d/io/file_format/FileOBJ.cpp
+++ b/open3d/io/file_format/FileOBJ.cpp
@@ -1,3 +1,5 @@
+#if false
+
 // ----------------------------------------------------------------------------
 // -                        Open3D: www.open3d.org                            -
 // ----------------------------------------------------------------------------
@@ -492,3 +494,5 @@ bool WriteTriangleMeshToOBJ(const std::string &filename, const geometry::Triangl
 
 }  // namespace io
 }  // namespace open3d
+
+#endif

--- a/open3d/io/file_format/FileOBJ.cpp
+++ b/open3d/io/file_format/FileOBJ.cpp
@@ -200,35 +200,15 @@ bool ReadTriangleMeshFromOBJ(const std::string &filename, geometry::TriangleMesh
       meshMaterial.baseColor = MaterialParameter::CreateRGB(material.diffuse[0], material.diffuse[1], material.diffuse[2]);
     }
 
-    if (!material.normal_texname.empty()) {
-      meshMaterial.normalMap = reference_texture(material.normal_texname);
-    } else if (!material.bump_texname.empty()) {
-      // try bump, because there is often a misunderstanding of
-      // what bump map or normal map is
-      meshMaterial.normalMap = reference_texture(material.bump_texname);
-    }
-
-    if (!material.ambient_occlusion_texname.empty()) {
-      meshMaterial.ambientOcclusion = reference_texture(material.ambient_occlusion_texname);
-    }
-
-    if (!material.diffuse_texname.empty()) {
-      meshMaterial.gltfExtras.texture_idx = reference_texture(material.diffuse_texname);
-      mesh.textures_names_.push_back(material.diffuse_texname);
-    }
-
-    if (!material.metallic_texname.empty()) {
-      meshMaterial.metallic = reference_texture(material.metallic_texname);
-    }
-
-    if (!material.roughness_texname.empty()) {
-      meshMaterial.roughness = reference_texture(material.roughness_texname);
+    meshMaterial.normalMap = reference_texture(!material.normal_texname.empty() ? material.normal_texname : material.bump_texname);
+    meshMaterial.ambientOcclusion = reference_texture(material.ambient_occlusion_texname);
+    meshMaterial.gltfExtras.texture_idx = reference_texture(material.diffuse_texname);
+    meshMaterial.metallic = reference_texture(material.metallic_texname);
+    meshMaterial.roughness = reference_texture(material.roughness_texname);
+    if (meshMaterial.roughness.has_value()) {
       std::cout << "Loaded roughness from OBJ file " << std::endl;
     }
-
-    if (!material.sheen_texname.empty()) {
-      meshMaterial.reflectance = reference_texture(material.sheen_texname);
-    }
+    meshMaterial.reflectance = reference_texture(material.sheen_texname);
 
     // NOTE: We want defaults of 0.0 and 1.0 for baseMetallic and
     // baseRoughness respectively but 0.0 is a valid value for both and

--- a/open3d/io/file_format/FileOBJ.cpp
+++ b/open3d/io/file_format/FileOBJ.cpp
@@ -143,7 +143,7 @@ bool ReadTriangleMeshFromOBJ(const std::string &filename, geometry::TriangleMesh
         if (!attrib.texcoords.empty() && 2 * idx.texcoord_index + 1 < int(attrib.texcoords.size())) {
           tinyobj::real_t tx = attrib.texcoords[2 * idx.texcoord_index + 0];
           tinyobj::real_t ty = attrib.texcoords[2 * idx.texcoord_index + 1];
-          mesh.triangle_uvs_.push_back(Eigen::Vector2d(tx, ty));
+          mesh.triangle_uvs_.push_back(Eigen::Vector2d(tx, 1.0f - ty));
         }
       }
       mesh.triangles_.push_back(facet);

--- a/open3d/io/file_format/FileOBJ.cpp
+++ b/open3d/io/file_format/FileOBJ.cpp
@@ -198,6 +198,8 @@ bool ReadTriangleMeshFromOBJ(const std::string &filename, geometry::TriangleMesh
       // background color of the texture, only used when the texture has an alpha channel < 1.
       // However, gltf and our renderer treats baseColor as a multiplier for the texture.
       meshMaterial.baseColor = MaterialParameter::CreateRGB(material.diffuse[0], material.diffuse[1], material.diffuse[2]);
+    } else {
+      meshMaterial.baseColor = MaterialParameter::CreateRGB(1.0f, 1.0f, 1.0f);
     }
 
     meshMaterial.normalMap = reference_texture(!material.normal_texname.empty() ? material.normal_texname : material.bump_texname);


### PR DESCRIPTION
Changed all the ancillary textures (normal maps, occlusion maps, etc...) from being independent `geometry::Image` objects to now be references in `geometry::TriangleMesh::textures_` for the sake of consistency. This also required changes to the GLB and OBJ readers and writers. Also took the opportunity to fix a few bugs where certainly newly added maps weren't considered in all operations and changed the OBJ reader from flipping the textures to flipping the V coordinate instead.