### PR TITLE
Support TextureLoadMode for OBJ

### DIFF
--- a/open3d/geometry/TriangleMesh.cpp
+++ b/open3d/geometry/TriangleMesh.cpp
@@ -1665,9 +1665,6 @@ bool TriangleMesh::Material::GltfExtras::operator<(const GltfExtras &other) cons
   if (texture_idx != other.texture_idx) {
     return (texture_idx < other.texture_idx);
   }
-  if (extensions != other.extensions) {
-    return (extensions < other.extensions);
-  }
   if (extension_images != other.extension_images) {
     return (extension_images < other.extension_images);
   }

--- a/open3d/geometry/TriangleMesh.h
+++ b/open3d/geometry/TriangleMesh.h
@@ -768,7 +768,7 @@ class TriangleMesh : public MeshBase {
       bool operator==(const GltfExtras &other) const {
         return (doubleSided == other.doubleSided && alphaMode == other.alphaMode && alphaCutoff == other.alphaCutoff &&
                 emissiveFactor == other.emissiveFactor && emissiveTexture == other.emissiveTexture && texture_idx == other.texture_idx &&
-                extensions == other.extensions && extension_images == other.extension_images &&
+                extension_images == other.extension_images &&
                 texture_from_specular_glossiness_diffuse == other.texture_from_specular_glossiness_diffuse);
       }
 

--- a/open3d/io/ImageIO.h
+++ b/open3d/io/ImageIO.h
@@ -33,14 +33,23 @@
 namespace open3d {
 namespace io {
 
+enum class TextureLoadMode {
+  normal,
+  pass_through,          // Textures are not decoded on loading, nor encoded on writing. Only available with GLB, GLTF, and OBJ files.
+  ignore_external_files  // External texture files are neither read or written on writing. Only available with GLTF files. Resorts to
+                         // pass through on GLB and OBJ files, embedded textures on GLTF files and is ignored on other formats.
+};
+
+std::vector<uint8_t> ReadFileIntoBuffer(const std::string &path);
+
 /// Factory function to create an image from a file (ImageFactory.cpp)
 /// Return an empty image if fail to read the file.
-std::shared_ptr<geometry::Image> CreateImageFromFile(const std::string &filename);
+std::shared_ptr<geometry::Image> CreateImageFromFile(const std::string &filename, TextureLoadMode texture_load_mode = TextureLoadMode::normal);
 
 /// The general entrance for reading an Image from a file
 /// The function calls read functions based on the extension name of filename.
 /// \return return true if the read function is successful, false otherwise.
-bool ReadImage(const std::string &filename, geometry::Image &image);
+bool ReadImage(const std::string &filename, geometry::Image &image, TextureLoadMode texture_load_mode = TextureLoadMode::normal);
 
 /// The general entrance for writing an Image to a file
 /// The function calls write functions based on the extension name of filename.

--- a/open3d/io/TriangleMeshIO.cpp
+++ b/open3d/io/TriangleMeshIO.cpp
@@ -52,7 +52,9 @@ static const std::function<bool(const std::string &, geometry::TriangleMesh &, b
       }
     }
   } else if (ext == "obj") {
-    return ReadTriangleMeshFromOBJ;
+    return [texture_load_mode] (const std::string &filename, geometry::TriangleMesh &mesh, bool print_progress) {
+      return ReadTriangleMeshFromOBJ(filename, mesh, print_progress, texture_load_mode);
+    };
   } else if (ext == "ply") {
     return ReadTriangleMeshFromPLY;
   } else if (ext == "stl") {

--- a/open3d/io/TriangleMeshIO.h
+++ b/open3d/io/TriangleMeshIO.h
@@ -29,6 +29,7 @@
 #include <string>
 
 #include "open3d/geometry/TriangleMesh.h"
+#include "open3d/io/ImageIO.h"
 
 namespace open3d {
 namespace io {
@@ -36,13 +37,6 @@ namespace io {
 /// Factory function to create a mesh from a file (TriangleMeshFactory.cpp)
 /// Return an empty mesh if fail to read the file.
 std::shared_ptr<geometry::TriangleMesh> CreateMeshFromFile(const std::string &filename, bool print_progress = false);
-
-enum class TextureLoadMode {
-  normal,
-  pass_through, // Textures are not decoded on loading, nor encoded on writing. Only available with GLB and GLTF files.
-  ignore_external_files // External texture files are neither read or written on writing. Only available with GLTF files. Resorts to
-      // pass through on GLB files, embedded textures on GLTF files and is ignored on other formats.
-};
 
 /// The general entrance for reading a TriangleMesh from a file
 /// The function calls read functions based on the extension name of filename.
@@ -72,7 +66,8 @@ bool ReadTriangleMeshFromSTL(const std::string &filename, geometry::TriangleMesh
 bool WriteTriangleMeshToSTL(const std::string &filename, const geometry::TriangleMesh &mesh, bool write_ascii, bool compressed,
                             bool write_vertex_normals, bool write_vertex_colors, bool write_triangle_uvs, bool print_progress);
 
-bool ReadTriangleMeshFromOBJ(const std::string &filename, geometry::TriangleMesh &mesh, bool print_progress);
+bool ReadTriangleMeshFromOBJ(const std::string &filename, geometry::TriangleMesh &mesh, bool print_progress,
+                             TextureLoadMode texture_load_mode);
 
 bool WriteTriangleMeshToOBJ(const std::string &filename, const geometry::TriangleMesh &mesh, bool write_ascii, bool compressed,
                             bool write_vertex_normals, bool write_vertex_colors, bool write_triangle_uvs, bool print_progress);

--- a/open3d/io/file_format/FileGLTF.cpp
+++ b/open3d/io/file_format/FileGLTF.cpp
@@ -55,17 +55,6 @@ static std::string GetMimeType(const tinygltf::Image &image) {
   return (utility::filesystem::GetMimeType(image.uri));
 }
 
-static std::vector<uint8_t> ReadFileIntoBuffer(const std::string &path) {
-  auto stream = std::ifstream(path, std::ios::in | std::ios::binary);
-  stream.seekg(0, std::ios::end);
-  auto size = stream.tellg();
-  stream.seekg(0);
-  std::vector<uint8_t> buffer(size);
-  stream.read((char *)buffer.data(), size);
-  stream.close();
-  return (buffer);
-}
-
 static void WriteFileFromBuffer(const std::string &path, const std::vector<uint8_t> &buffer) {
   auto stream = std::ofstream(path, std::ios::out | std::ios::binary);
   stream.write(reinterpret_cast<const std::ofstream::char_type *>(buffer.data()), buffer.size());


### PR DESCRIPTION
Add support for `TextureLoadMode::pass_through` and `TextureLoadMode::ignore_external_files` when loading obj files so we can convert obj -> glb without decoding textures to save memory and time.

Tested by importing https://storage.polycam.io/captures/7e0e891c-573a-43f7-8de3-0e900b74f185/raw_import.zip, which has 357 2048x2048 textures.